### PR TITLE
Add IPv6 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "agent"
-version = "0.7.5-beta"
+version = "0.8.0-beta"
 dependencies = [
  "agent-common",
  "byteorder",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "agent-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "byteorder",

--- a/packages/agent/Cargo.toml
+++ b/packages/agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.7.5-beta"
+version = "0.8.0-beta"
 edition = "2021"
 description = "using playit.gg makes it possible to host game servers at home without port forwarding"
 homepage = "https://playit.gg"

--- a/packages/agent/src/api_client.rs
+++ b/packages/agent/src/api_client.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{SocketAddr, SocketAddrV6};
 
 use hyper::{Body, header, Method, Request};
 use hyper::body::Buf;
@@ -15,17 +15,26 @@ use agent_common::rpc::SignedRpcRequest;
 pub struct ApiClient {
     api_base: String,
     agent_secret: Option<String>,
-    client: hyper::Client<HttpsConnector<HttpConnector>, hyper::Body>,
+    client: hyper::Client<HttpsConnector<HttpConnector>, Body>,
 }
 
 impl ApiClient {
     pub fn new(api_base: String, agent_secret: Option<String>) -> Self {
-        let connector = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_only()
-            .enable_http1()
-            .enable_http2()
-            .build();
+        let connector = if api_base.starts_with("http://") {
+            HttpsConnectorBuilder::new()
+                .with_webpki_roots()
+                .https_or_http()
+                .enable_http1()
+                .enable_http2()
+                .build()
+        } else {
+            HttpsConnectorBuilder::new()
+                .with_webpki_roots()
+                .https_only()
+                .enable_http1()
+                .enable_http2()
+                .build()
+        };
 
         ApiClient {
             api_base,

--- a/packages/agent_common/Cargo.toml
+++ b/packages/agent_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-common"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/agent_common/src/agent_config.rs
+++ b/packages/agent_common/src/agent_config.rs
@@ -14,6 +14,8 @@ pub struct AgentConfig {
     pub last_update: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub control_address: Option<SocketAddr>,
     #[serde(default)]
     pub refresh_from_api: bool,
     pub secret_key: String,
@@ -66,7 +68,7 @@ pub struct PortMappingConfig {
 impl AgentConfig {
     pub fn find_local_addr(
         &self,
-        addr: SocketAddrV4,
+        addr: SocketAddr,
         proto: Proto,
     ) -> Option<(Option<IpAddr>, SocketAddr)> {
         for mapping in &self.mappings {
@@ -76,7 +78,7 @@ impl AgentConfig {
                 _ => {}
             }
 
-            if !mapping.tunnel_ip.eq(addr.ip()) {
+            if !mapping.tunnel_ip.eq(&addr.ip()) {
                 continue;
             }
 

--- a/packages/agent_common/src/auth.rs
+++ b/packages/agent_common/src/auth.rs
@@ -65,12 +65,13 @@ impl Signature {
         match self {
             Signature::System(s) => s
                 .validate(details, data, secret)
-                .map(|account_id| Authorization::SystemLevel { account_id }),
+                .map(|account_id| Authorization::SystemLevel { account_id, sig_epoch: details.request_timestamp }),
             Signature::Session(s) => {
                 s.validate(details, now, data, secret)
                     .map(|(account_id, session_id)| Authorization::SessionLevel {
                         account_id,
                         session_id,
+                        sig_epoch: s.session_timestamp,
                     })
             }
         }
@@ -189,8 +190,8 @@ pub fn generate_signature(
 
 #[derive(Debug)]
 pub enum Authorization {
-    SystemLevel { account_id: u64 },
-    SessionLevel { account_id: u64, session_id: u64 },
+    SystemLevel { account_id: u64, sig_epoch: u64, },
+    SessionLevel { account_id: u64, session_id: u64, sig_epoch: u64, },
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/packages/agent_common/src/rpc.rs
+++ b/packages/agent_common/src/rpc.rs
@@ -27,7 +27,7 @@ impl<T: DeserializeOwned + Serialize + Debug> Debug for SignedRpcRequest<T> {
         write!(
             f,
             "SignedRpcRequest {{ content: {:?}, auth: {} }} ",
-            self.content,
+            bincode::deserialize::<T>(&self.content),
             match &self.auth {
                 None => Cow::Borrowed("None"),
                 Some(auth) => {
@@ -151,11 +151,8 @@ impl<T: DeserializeOwned + Serialize> SignedRpcRequest<T> {
             .map(Some)
     }
 
-    pub fn into_content(self) -> Result<T, Self> {
-        match bincode::deserialize(&self.content) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(self),
-        }
+    pub fn get_content(&self) -> Result<T, bincode::Error> {
+        bincode::deserialize(&self.content)
     }
 
     pub fn content_slice(&self) -> &[u8] {


### PR DESCRIPTION
Includes new agent config attribute `control_address` which
allows user or api to set which tunnel server the playit program
should communicate with. This offers more control to allow users
to pick which region they want to be routed to.
