### PR TITLE
improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Please only use the playit program if you downloaded if from an offical source o
 ## Building / Running Locally
 
 Requires Rust: https://rustup.rs
-Run using `cargo run --release --bin=agent`
-
+Run using `cargo run --release --bin=playit-cli`
+Binary will be in target/ directory


### PR DESCRIPTION
some importatant info was missing like where the actual binary is outputed, and the cargo command is wrong --bin needs to be playit-cli otherwise it fails to build
also fixes #38 