### PR TITLE
Fix address lookup for PortType::Both

### DIFF
--- a/packages/agent_cli/src/main.rs
+++ b/packages/agent_cli/src/main.rs
@@ -419,7 +419,7 @@ impl AddressLookup for LookupWithOverrides {
 
     fn lookup(&self, ip: IpAddr, port: u16, proto: PortType) -> Option<AddressValue<SocketAddr>> {
         for over in &self.0 {
-            if over.proto == proto && over.match_ip.matches(ip) {
+            if (over.proto == proto || over.proto == PortType::Both) && over.match_ip.matches(ip) {
                 return Some(AddressValue {
                     value: over.local_addr,
                     from_port: over.port.from,


### PR DESCRIPTION
If the port set in the UI is `TCP + UDP`, then override address lookup fails because `proto` isn't `Both`.
This should fix the issue. Let me know if there's a better way to achieve this without an additional check.