### PR TITLE
Fix async in playit_secret

### DIFF
--- a/packages/agent_cli/src/playit_secret.rs
+++ b/packages/agent_cli/src/playit_secret.rs
@@ -83,7 +83,7 @@ impl PlayitSecret {
                     break;
                 }
                 Err(ApiErrorNoFail::ClientError(error)) => {
-                    ui.write_error("Failed to load data from api\nretrying in 3 seconds", error);
+                    ui.write_error("Failed to load data from api\nretrying in 3 seconds", error).await;
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 }
                 Err(ApiErrorNoFail::ApiError(ApiResponseError::Auth(AuthError::InvalidAgentKey))) => {
@@ -102,7 +102,7 @@ impl PlayitSecret {
                     }
                 }
                 Err(ApiErrorNoFail::ApiError(error)) => {
-                    ui.write_error("unexpected error checking if secret is valid", &error);
+                    ui.write_error("unexpected error checking if secret is valid", &error).await;
                     tokio::time::sleep(Duration::from_secs(5)).await;
                     return Err(CliError::ApiError(error));
                 }
@@ -154,7 +154,7 @@ impl PlayitSecret {
         };
 
         if let Err(error) = tokio::fs::write(path, &content).await {
-            ui.write_error(format!("failed to save secret, path: {}", path), &error);
+            ui.write_error(format!("failed to save secret, path: {}", path), &error).await;
             tokio::time::sleep(Duration::from_secs(5)).await;
             return Err(CliError::SecretFileWriteError(error));
         }


### PR DESCRIPTION
Since Rust Futures are lazy and will not run unless `poll`ed (`await`ed) this code was never executed.