### PR TITLE
Changed entrypoint.sh to run playit not as root and added new env to run playit as root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=build-env /src/playit-agent/target/release/playit-cli /usr/local/bin/playit
 RUN mkdir /playit
-COPY docker/entrypoint.sh docker/usersetup.sh /playit/
-RUN chmod +x /playit/entrypoint.sh /playit/usersetup.sh
+COPY --chmod=1711 docker/entrypoint.sh docker/usersetup.sh /playit/
 
 ENTRYPOINT ["/playit/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=build-env /src/playit-agent/target/release/playit-cli /usr/local/bin/playit
 RUN mkdir /playit
-COPY docker/entrypoint.sh /playit/entrypoint.sh
-RUN chmod +x /playit/entrypoint.sh
+COPY docker/entrypoint.sh docker/usersetup.sh /playit/
+RUN chmod +x /playit/entrypoint.sh /playit/usersetup.sh
 
 ENTRYPOINT ["/playit/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,4 +10,9 @@ if [ -z "${SECRET_KEY}" ]; then
   fi
 fi
 
-playit -s --secret "${SECRET_KEY}" --platform_docker start
+if [ "${RUN_ROOT}" = true ] ; then
+  playit -s --secret "${SECRET_KEY}" --platform_docker start
+else
+  /playit/usersetup.sh
+  su -c 'playit -s --secret "${SECRET_KEY}" --platform_docker start' -s /bin/sh playit
+fi

--- a/docker/usersetup.sh
+++ b/docker/usersetup.sh
@@ -2,10 +2,10 @@
 
 if ! id "playit" >/dev/null 2>&1; then
   if [ -z "${PLAYIT_UUID}" ]; then
-    PLAYIT_UUID=1000
+    PLAYIT_UUID=2000
   fi
   if [ -z "${PLAYIT_GUID}" ]; then
-    PLAYIT_GUID=1000
+    PLAYIT_GUID=2000
   fi
   addgroup -g ${PLAYIT_GUID} playit
   adduser -HSs /sbin/nologin -u ${PLAYIT_UUID} -G playit playit

--- a/docker/usersetup.sh
+++ b/docker/usersetup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+if ! id "playit" >/dev/null 2>&1; then
+  if [ -z "${PLAYIT_UUID}" ]; then
+    PLAYIT_UUID=1000
+  fi
+  if [ -z "${PLAYIT_GUID}" ]; then
+    PLAYIT_GUID=1000
+  fi
+  addgroup -g ${PLAYIT_GUID} playit
+  adduser -Ss /sbin/nologin -u ${PLAYIT_UUID} -G playit -H playit
+fi

--- a/docker/usersetup.sh
+++ b/docker/usersetup.sh
@@ -8,5 +8,5 @@ if ! id "playit" >/dev/null 2>&1; then
     PLAYIT_GUID=1000
   fi
   addgroup -g ${PLAYIT_GUID} playit
-  adduser -Ss /sbin/nologin -u ${PLAYIT_UUID} -G playit -H playit
+  adduser -HSs /sbin/nologin -u ${PLAYIT_UUID} -G playit playit
 fi


### PR DESCRIPTION
The changes to `entrypoint.sh` allows and makes playit not run as root by default. If the user wishes to run playit as root for some reason they can add the env `RUN_ROOT = true`.  
This is achieved by creating a new system user that has no shell or home. A new script `usersetup.sh` is also added to keep `entrypoint.sh` cleaner. `usersetup.sh` will check if the user `playit` is already made before fully running.
The following env are also added and are defaulted to `1000` when not defined.  
`PLAYIT_UUID` allows the user to change the user ID of playit.
`PLAYIT_GUID` allows the user to change the group ID of playit.