### PR TITLE
Use Docker's chmod flag in copy and made playit no longer run as root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,15 @@ RUN cargo build --release --all
 ########## RUNTIME CONTAINER ##########
 
 FROM alpine:3.18
+ARG PLAYIT_GUID=2000
+ARG PLAYIT_UUID=2000
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build-env /src/playit-agent/target/release/playit-cli /usr/local/bin/playit
 RUN mkdir /playit
-COPY docker/entrypoint.sh /playit/entrypoint.sh
-RUN chmod +x /playit/entrypoint.sh
+COPY --chmod=1755 docker/entrypoint.sh /playit/
+
+RUN addgroup -g ${PLAYIT_GUID} playit && adduser -Sh /playit -u ${PLAYIT_UUID} -G playit playit
+USER playit
 
 ENTRYPOINT ["/playit/entrypoint.sh"]


### PR DESCRIPTION
As discussed in https://github.com/playit-cloud/playit-agent/pull/94
Playit will now run without root and has it USER set to non-root.
The following in the Dockerfile allows users to change the ID.
ARG PLAYIT_GUID=2000
ARG PLAYIT_UUID=2000
https://docs.docker.com/build/guide/build-args/
https://docs.docker.com/reference/compose-file/build/#args  
Ignore https://github.com/playit-cloud/playit-agent/pull/95 , I didn't mess up at all and didn't copy the whole Dockerfile.