### PR TITLE
fix(docker/entrypoint.sh): Use `exec` to replace the shell

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,4 +10,4 @@ if [ -z "${SECRET_KEY}" ]; then
   fi
 fi
 
-playit -s --secret "${SECRET_KEY}" --platform_docker start
+exec playit -s --secret "${SECRET_KEY}" --platform_docker start


### PR DESCRIPTION
This should be done to allow the container to properly react to unix signals (e.g., `SIGTERM`).

Currently, PID 1 is `sh` which is executing the script until the `playit` binary stops. When the pod is stopped, e.g., using `docker stop` or in Kubernetes, when the pod is being deleted, the container runtime sends a `SIGTERM` to PID 1 to allow for graceful termination. `sh` however, does not handle signals, which results in the container running indefinitely until the container runtime sends a `SIGKILL`.