### PR TITLE
HACK: delay data to origin to have entire init msg

### DIFF
--- a/packages/agent_core/src/network/tcp/tcp_client.rs
+++ b/packages/agent_core/src/network/tcp/tcp_client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde::Serialize;
 use tokio::net::TcpStream;
 use tokio_util::sync::CancellationToken;
@@ -17,8 +19,13 @@ impl TcpClient {
         let cancel = CancellationToken::new();
 
         TcpClient {
-            tunn_to_origin: TcpPipe::new_with_cancel(cancel.clone(), tunn_read, origin_write),
-            origin_to_tunn: TcpPipe::new_with_cancel(cancel, origin_read, tunn_write),
+            tunn_to_origin: TcpPipe::new_with_cancel(
+                cancel.clone(),
+                tunn_read,
+                origin_write,
+                Some(Duration::from_millis(100)),
+            ),
+            origin_to_tunn: TcpPipe::new_with_cancel(cancel, origin_read, tunn_write, None),
         }
     }
 


### PR DESCRIPTION
Seems like there's a legacy protocol that needs the entire client message received to properly parse the header. Delay passing data to origin by 100ms to allow agent to receive enough data (TM) before passing the request off to the origin.