### PR TITLE
Change container's default stop signal to SIGINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,6 @@ COPY --from=build-env /src/playit-agent/target/release/playit-cli /usr/local/bin
 RUN mkdir /playit
 COPY docker/entrypoint.sh /playit/entrypoint.sh
 RUN chmod +x /playit/entrypoint.sh
+STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/playit/entrypoint.sh"]

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -17,5 +17,6 @@ COPY --from=artifact-downloader /download/playit /usr/local/bin/playit
 RUN mkdir /playit
 COPY docker/entrypoint.sh /playit/entrypoint.sh
 RUN chmod +x /playit/entrypoint.sh
+STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/playit/entrypoint.sh"]


### PR DESCRIPTION
This PR changes the stop signal from docker's default `SIGTERM` to `SIGINT`, which is the signal that playit agent listens to, this allows container to shutdown gracefully.