### PR TITLE
Switch Linux packaging to manage playit systemd unit

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Package .deb
         shell: bash
-        run: 'bash ./build-scripts/package-linux-deb.sh "./target/${{ matrix.platform.arch }}/release/playit-cli" ${{ matrix.platform.dpkg_arch }}'
+        run: 'bash ./build-scripts/package-linux-deb.sh "./target/${{ matrix.platform.arch }}/release/playit-cli" "./target/${{ matrix.platform.arch }}/release/playitd" ${{ matrix.platform.dpkg_arch }}'
 
       - name: Upload .deb
         uses: actions/upload-release-asset@v1

--- a/build-scripts/package-linux-deb.sh
+++ b/build-scripts/package-linux-deb.sh
@@ -4,8 +4,41 @@ START_DIR="$(pwd)"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-SRC_PATH="$1"
-DEB_ARCH="$2"
+if [[ $# -ne 2 && $# -ne 3 ]]; then
+  echo "usage: $0 <playit-cli-binary> [playitd-binary] <deb-arch>" >&2
+  exit 1
+fi
+
+resolve_input_path() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${START_DIR}" "$1"
+  fi
+}
+
+CLI_SRC_PATH="$1"
+
+if [[ $# -eq 3 ]]; then
+  DAEMON_SRC_PATH="$2"
+  DEB_ARCH="$3"
+else
+  DAEMON_SRC_PATH="$(dirname "${CLI_SRC_PATH}")/playitd"
+  DEB_ARCH="$2"
+fi
+
+CLI_BIN="$(resolve_input_path "${CLI_SRC_PATH}")"
+DAEMON_BIN="$(resolve_input_path "${DAEMON_SRC_PATH}")"
+
+if [[ ! -f "${CLI_BIN}" ]]; then
+  echo "playit CLI binary not found: ${CLI_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${DAEMON_BIN}" ]]; then
+  echo "playit daemon binary not found: ${DAEMON_BIN}" >&2
+  exit 1
+fi
 
 TEMP_DIR_NAME="temp-build-${DEB_ARCH}"
 
@@ -33,7 +66,9 @@ WK_DIR=$(pwd)
 echo "PREPARE BINARY AND RUN SCRIPT"
 mkdir -p "${WK_DIR}${INSTALL_FOLDER}"
 
-cp "${START_DIR}/${SRC_PATH}" "${WK_DIR}${INSTALL_FOLDER}/agent"
+cp "${CLI_BIN}" "${WK_DIR}${INSTALL_FOLDER}/agent"
+cp "${DAEMON_BIN}" "${WK_DIR}${INSTALL_FOLDER}/playitd"
+chmod 0755 "${WK_DIR}${INSTALL_FOLDER}/agent" "${WK_DIR}${INSTALL_FOLDER}/playitd"
 
 # Create run script
 echo "#!/bin/bash
@@ -65,11 +100,23 @@ Depends: logrotate
 # setup script
 cat <<EOF > "${WK_DIR}/DEBIAN/postinst"
 #!/bin/bash
-ln -s ${INSTALL_FOLDER}/playit /usr/local/bin/playit
+set -e
+
+mkdir -p /usr/local/bin
+ln -sfn ${INSTALL_FOLDER}/playit /usr/local/bin/playit
 mkdir -p /var/log/playit # make logs folder
 chmod 0766 -R /var/log/playit
 mkdir -p /etc/playit
 chmod 0777 /etc/playit
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl is required to install playit" >&2
+  exit 1
+fi
+
+systemctl daemon-reload
+systemctl enable playit
+systemctl restart playit || systemctl start playit
 EOF
 chmod 0555 "${WK_DIR}/DEBIAN/postinst"
 

--- a/linux/playit.service
+++ b/linux/playit.service
@@ -5,7 +5,7 @@ Wants=network-pre.target
 After=network-pre.target NetworkManager.service systemd-resolved.service
 
 [Service]
-ExecStart=/opt/playit/playit --secret_wait --secret_path /etc/playit/playit.toml -l /var/log/playit/playit.log start
+ExecStart=/opt/playit/playitd --secret_path /etc/playit/playit.toml -l /var/log/playit/playit.log
 Restart=on-failure
 
 [Install]

--- a/packages/playitd/src/manager.rs
+++ b/packages/playitd/src/manager.rs
@@ -8,6 +8,9 @@ pub const INSTALLED_SERVICE_LABEL: &str = "playitd";
 #[cfg(not(target_os = "windows"))]
 pub const INSTALLED_SERVICE_LABEL: &str = "gg.playit.playitd";
 
+#[cfg(target_os = "linux")]
+const SYSTEMD_SERVICE_NAME: &str = "playit";
+
 #[derive(Debug)]
 pub enum ServiceManagerError {
     NotAvailable(String),
@@ -81,12 +84,22 @@ impl ServiceController {
 
 #[cfg(target_os = "linux")]
 fn start_systemd_service() -> Result<(), ServiceManagerError> {
-    run_systemctl(&["start", "playitd"], ServiceManagerError::StartFailed)
+    run_systemctl(&systemd_start_args(), ServiceManagerError::StartFailed)
 }
 
 #[cfg(target_os = "linux")]
 pub fn stop_systemd_service() -> Result<(), ServiceManagerError> {
-    run_systemctl(&["stop", "playitd"], ServiceManagerError::StopFailed)
+    run_systemctl(&systemd_stop_args(), ServiceManagerError::StopFailed)
+}
+
+#[cfg(target_os = "linux")]
+fn systemd_start_args() -> [&'static str; 2] {
+    ["start", SYSTEMD_SERVICE_NAME]
+}
+
+#[cfg(target_os = "linux")]
+fn systemd_stop_args() -> [&'static str; 2] {
+    ["stop", SYSTEMD_SERVICE_NAME]
 }
 
 #[cfg(target_os = "linux")]
@@ -156,4 +169,19 @@ async fn wait_for_installed_service() -> Result<(), ServiceManagerError> {
     Err(ServiceManagerError::StartFailed(
         "Service did not start within timeout".to_string(),
     ))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::{systemd_start_args, systemd_stop_args};
+
+    #[test]
+    fn linux_start_targets_playit_unit() {
+        assert_eq!(systemd_start_args(), ["start", "playit"]);
+    }
+
+    #[test]
+    fn linux_stop_targets_playit_unit() {
+        assert_eq!(systemd_stop_args(), ["stop", "playit"]);
+    }
 }


### PR DESCRIPTION
- Package both `playit` CLI and `playitd` daemon in the .deb
- Install and control the `playit` systemd service during postinst
- Update Linux service launch target and add unit-target tests