### PR TITLE
Resolve origin hostnames asynchronously

### DIFF
--- a/packages/agent_core/src/network/origin_lookup.rs
+++ b/packages/agent_core/src/network/origin_lookup.rs
@@ -6,6 +6,7 @@ use std::{
 
 use playit_agent_proto::PortProto;
 use playit_api_client::api::{AgentRunDataV1, AgentTunnelV1, PortType, ProxyProtocol, TunnelType};
+use tokio::net::lookup_host;
 use tokio::sync::RwLock;
 
 #[derive(Default)]
@@ -95,19 +96,64 @@ pub struct OriginResource {
 }
 
 #[derive(Debug, Clone)]
+pub enum OriginIp {
+    IpAddress(IpAddr),
+    Hostname(String),
+}
+
+impl OriginIp {
+    async fn resolve(&self, port: u16) -> Option<SocketAddr> {
+        match self {
+            OriginIp::IpAddress(ip) => Some(SocketAddr::new(*ip, port)),
+            OriginIp::Hostname(hostname) => {
+                let mut addrs = match lookup_host((hostname.as_str(), port)).await {
+                    Ok(addrs) => addrs,
+                    Err(error) => {
+                        tracing::error!(
+                            ?error,
+                            %hostname,
+                            port,
+                            "failed to resolve origin hostname"
+                        );
+                        return None;
+                    }
+                };
+
+                addrs.next()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum OriginTarget {
     Https {
-        ip: IpAddr,
+        ip: OriginIp,
         http_port: u16,
         https_port: u16,
     },
     Port {
-        ip: IpAddr,
+        ip: OriginIp,
         port: u16,
     },
 }
 
 impl OriginResource {
+    fn parse_origin_ip(tunn: &AgentTunnelV1) -> OriginIp {
+        tunn.agent_config
+            .fields
+            .iter()
+            .find(|f| f.name.eq("local_ip"))
+            .map(|v| v.value.trim())
+            .filter(|v| !v.is_empty())
+            .map(|value| {
+                IpAddr::from_str(value)
+                    .map(OriginIp::IpAddress)
+                    .unwrap_or_else(|_| OriginIp::Hostname(value.to_owned()))
+            })
+            .unwrap_or_else(|| OriginIp::IpAddress("127.0.0.1".parse().unwrap()))
+    }
+
     pub fn from_agent_tunnel(tunn: &AgentTunnelV1) -> Option<Self> {
         let tunnel_type = tunn
             .tunnel_type
@@ -126,13 +172,7 @@ impl OriginResource {
 
         let target = match tunnel_type {
             Some(TunnelType::Https) => OriginTarget::Https {
-                ip: tunn
-                    .agent_config
-                    .fields
-                    .iter()
-                    .find(|f| f.name.eq("local_ip"))
-                    .and_then(|v| IpAddr::from_str(&v.value).ok())
-                    .unwrap_or_else(|| "127.0.0.1".parse().unwrap()),
+                ip: Self::parse_origin_ip(tunn),
                 http_port: tunn
                     .agent_config
                     .fields
@@ -165,13 +205,7 @@ impl OriginResource {
                     })?;
 
                 OriginTarget::Port {
-                    ip: tunn
-                        .agent_config
-                        .fields
-                        .iter()
-                        .find(|f| f.name.eq("local_ip"))
-                        .and_then(|v| IpAddr::from_str(&v.value).ok())
-                        .unwrap_or_else(|| "127.0.0.1".parse().unwrap()),
+                    ip: Self::parse_origin_ip(tunn),
                     port: local_port,
                 }
             }
@@ -190,7 +224,7 @@ impl OriginResource {
         })
     }
 
-    pub fn resolve_local(&self, port_offset: u16) -> Option<SocketAddr> {
+    pub async fn resolve_local(&self, port_offset: u16) -> Option<SocketAddr> {
         match &self.target {
             OriginTarget::Https {
                 ip,
@@ -198,24 +232,102 @@ impl OriginResource {
                 https_port,
             } => {
                 if port_offset == 0 {
-                    Some(SocketAddr::new(*ip, *http_port))
+                    ip.resolve(*http_port).await
                 } else if port_offset == 1 {
-                    Some(SocketAddr::new(*ip, *https_port))
+                    ip.resolve(*https_port).await
                 } else {
                     None
                 }
             }
             OriginTarget::Port { ip, port } => {
                 if self.port_count == 0 {
-                    return Some(SocketAddr::new(*ip, *port));
+                    return ip.resolve(*port).await;
                 }
 
                 if self.port_count <= port_offset {
                     return None;
                 }
 
-                Some(SocketAddr::new(*ip, *port + port_offset))
+                let resolved_port = port.checked_add(port_offset)?;
+                ip.resolve(resolved_port).await
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use playit_api_client::api::{AgentTunnelAttr, AgentTunnelConfig};
+    use uuid::Uuid;
+
+    fn build_tunnel(
+        tunnel_type: Option<&str>,
+        local_ip: &str,
+        local_port: Option<&str>,
+        port_type: PortType,
+        port_count: u16,
+    ) -> AgentTunnelV1 {
+        let mut fields = vec![AgentTunnelAttr {
+            name: "local_ip".to_owned(),
+            value: local_ip.to_owned(),
+        }];
+
+        if let Some(local_port) = local_port {
+            fields.push(AgentTunnelAttr {
+                name: "local_port".to_owned(),
+                value: local_port.to_owned(),
+            });
+        }
+
+        AgentTunnelV1 {
+            id: Uuid::nil(),
+            internal_id: 7,
+            name: "test".to_owned(),
+            display_address: "public.example:25565".to_owned(),
+            port_type,
+            port_count,
+            tunnel_type: tunnel_type.map(str::to_owned),
+            tunnel_type_display: "test".to_owned(),
+            agent_config: AgentTunnelConfig { fields },
+            disabled_reason: None,
+        }
+    }
+
+    #[test]
+    fn from_agent_tunnel_preserves_hostname_target() {
+        let tunnel = build_tunnel(None, "origin.internal", Some("25565"), PortType::Tcp, 0);
+
+        let resource = OriginResource::from_agent_tunnel(&tunnel).expect("resource");
+
+        match resource.target {
+            OriginTarget::Port {
+                ip: OriginIp::Hostname(hostname),
+                port,
+            } => {
+                assert_eq!(hostname, "origin.internal");
+                assert_eq!(port, 25565);
+            }
+            target => panic!("unexpected target: {target:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_local_supports_hostname_lookup() {
+        let resource = OriginResource {
+            tunnel_id: 1,
+            proto: PortProto::Tcp,
+            target: OriginTarget::Port {
+                ip: OriginIp::Hostname("localhost".to_owned()),
+                port: 8080,
+            },
+            port_count: 0,
+            proxy_protocol: None,
+        };
+
+        let resolved = resource.resolve_local(0).await.expect("resolved");
+
+        assert_eq!(resolved.port(), 8080);
+        assert!(resolved.ip().is_loopback());
     }
 }

--- a/packages/agent_core/src/network/tcp/tcp_clients.rs
+++ b/packages/agent_core/src/network/tcp/tcp_clients.rs
@@ -218,7 +218,7 @@ impl Worker {
                         }
                     };
 
-                    let Some(origin_addr) = found.resolve_local(details.port_offset) else {
+                    let Some(origin_addr) = found.resolve_local(details.port_offset).await else {
                         tracing::error!(
                             port_offset = details.port_offset,
                             tunnel_id = details.tunnel_id,

--- a/packages/agent_core/src/network/tcp/tcp_clients.rs
+++ b/packages/agent_core/src/network/tcp/tcp_clients.rs
@@ -218,21 +218,22 @@ impl Worker {
                         }
                     };
 
-                    let Some(origin_addr) = found.resolve_local(details.port_offset).await else {
-                        tracing::error!(
-                            port_offset = details.port_offset,
-                            tunnel_id = details.tunnel_id,
-                            "port offset not valid for tunnel"
-                        );
-                        tcp_errors().new_client_invalid_port_offset.inc();
-                        continue;
-                    };
-
                     let setting_tcp_no_delay = self.settings.tcp_no_delay;
 
                     let event_tx = self.events_tx.clone();
                     let stats = self.stats.clone();
                     tokio::spawn(async move {
+                        let Some(origin_addr) = found.resolve_local(details.port_offset).await
+                        else {
+                            tracing::error!(
+                                port_offset = details.port_offset,
+                                tunnel_id = details.tunnel_id,
+                                "port offset not valid for tunnel"
+                            );
+                            tcp_errors().new_client_invalid_port_offset.inc();
+                            return;
+                        };
+
                         /* connect to tunnel server */
 
                         let conn_res = tokio::time::timeout(

--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -221,16 +221,8 @@ impl UdpClients {
             tunnel_id: extension.tunnel_id.get(),
         };
 
-        let Some(target_addr) = origin.resolve_local(extension.port_offset).await else {
-            return;
-        };
-        let SocketAddr::V4(target_addr) = target_addr else {
-            return;
-        };
-
         // Track bytes coming in (from tunnel to origin)
         let packet_len = packet.len() as u64;
-        self.stats.add_bytes_in(packet_len);
 
         if let Some(&slot) = self.virtual_client_lookup.get(&key) {
             let receiver_closed = self
@@ -245,12 +237,14 @@ impl UdpClients {
                 client.from_tunnel_ts = now_ms;
                 if client
                     .socket
-                    .send_to(packet.as_ref(), target_addr)
+                    .send_to(packet.as_ref(), client.target_addr)
                     .await
                     .is_err()
                 {
                     udp_errors().origin_send_io_error.inc();
                 }
+
+                self.stats.add_bytes_in(packet_len);
                 return;
             }
 
@@ -265,6 +259,14 @@ impl UdpClients {
             udp_errors().new_client_ratelimit.inc();
             return;
         }
+
+        let Some(target_addr) = origin.resolve_local(extension.port_offset).await else {
+            return;
+        };
+
+        let SocketAddr::V4(target_addr) = target_addr else {
+            return;
+        };
 
         let special_lan = target_addr.ip().is_loopback() && origin.proxy_protocol.is_none();
 

--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::{IpAddr, SocketAddr, SocketAddrV4},
+    net::{SocketAddr, SocketAddrV4},
     num::NonZeroU32,
     sync::{
         Arc,
@@ -17,9 +17,7 @@ use tokio::{
 };
 
 use crate::network::{
-    lan_address::LanAddress,
-    origin_lookup::{OriginLookup, OriginTarget},
-    proxy_protocol::ProxyProtocolHeader,
+    lan_address::LanAddress, origin_lookup::OriginLookup, proxy_protocol::ProxyProtocolHeader,
 };
 use crate::stats::AgentStats;
 use playit_agent_proto::udp_proto::UdpFlow;
@@ -48,6 +46,8 @@ struct Client {
     id: u64,
     key: UdpClientKey,
     socket: Arc<UdpSocket>,
+    target_addr: SocketAddrV4,
+    port_offset: u16,
     flow: UdpFlow,
 
     /* when dropped, rx task get killed */
@@ -166,39 +166,17 @@ impl UdpClients {
             return None;
         }
 
-        let Some(tunnel) = self.lookup.lookup(client.key.tunnel_id, false).await else {
-            udp_errors().origin_tunnel_not_found.inc();
-            return None;
-        };
-
         let SocketAddr::V4(source) = packet.from else {
             udp_errors().origin_source_not_ip4.inc();
             return None;
         };
 
-        let OriginTarget::Port {
-            ip: local_ip,
-            port: port_start,
-        } = &tunnel.target
-        else {
-            return None;
-        };
-
-        if *local_ip != IpAddr::V4(*source.ip()) {
+        if source != client.target_addr {
             udp_errors().origin_reject_addr_differ.inc();
             return None;
         }
 
-        if source.port() < *port_start {
-            udp_errors().origin_reject_port_too_low.inc();
-            return None;
-        }
-
-        let port_offset = source.port() - *port_start;
-        if tunnel.resolve_local(port_offset) != Some(packet.from) {
-            udp_errors().origin_reject_port_too_high.inc();
-            return None;
-        }
+        let port_offset = client.port_offset;
 
         client.from_origin_ts = now_ms;
 
@@ -243,7 +221,7 @@ impl UdpClients {
             tunnel_id: extension.tunnel_id.get(),
         };
 
-        let Some(target_addr) = origin.resolve_local(extension.port_offset) else {
+        let Some(target_addr) = origin.resolve_local(extension.port_offset).await else {
             return;
         };
         let SocketAddr::V4(target_addr) = target_addr else {
@@ -337,6 +315,8 @@ impl UdpClients {
             id,
             key: key.clone(),
             socket,
+            target_addr,
+            port_offset: extension.port_offset,
             receiver,
             flow: client_flow,
             from_tunnel_ts: now_ms,


### PR DESCRIPTION
- Allow origin local_ip to be a hostname as well as an IP
- Resolve origin targets asynchronously in TCP and UDP clients
- Add tests for hostname parsing and lookup