### PR TITLE
Support IPv6 UDP origin addresses

### DIFF
--- a/packages/agent_core/src/network/lan_address.rs
+++ b/packages/agent_core/src/network/lan_address.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use byteorder::{BigEndian, ByteOrder};
 use tokio::net::{TcpSocket, TcpStream, UdpSocket};
@@ -58,6 +58,7 @@ impl LanAddress {
     pub async fn udp_socket(
         special_lan_ip: bool,
         peer: SocketAddr,
+        target: SocketAddr,
         tunnel_id: u64,
     ) -> std::io::Result<UdpSocket> {
         let ip_shuffle = shuffle_ip_to_u32(peer.ip());
@@ -97,10 +98,25 @@ impl LanAddress {
                 }
             }
         } else {
-            match UdpSocket::bind(SocketAddrV4::new(0.into(), local_port)).await {
+            let bind_addr = match target {
+                SocketAddr::V4(_) => {
+                    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, local_port))
+                }
+                SocketAddr::V6(_) => {
+                    SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, local_port, 0, 0))
+                }
+            };
+            let fallback_addr = match target {
+                SocketAddr::V4(_) => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
+                SocketAddr::V6(_) => {
+                    SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0))
+                }
+            };
+
+            match UdpSocket::bind(bind_addr).await {
                 Ok(v) => Ok(v),
                 Err(bad_port_error) => {
-                    let v = UdpSocket::bind(SocketAddrV4::new(0.into(), 0)).await?;
+                    let v = UdpSocket::bind(fallback_addr).await?;
                     tracing::warn!("Failed to bind UDP to special port: {:?}", bad_port_error);
                     Ok(v)
                 }

--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -46,7 +46,7 @@ struct Client {
     id: u64,
     key: UdpClientKey,
     socket: Arc<UdpSocket>,
-    target_addr: SocketAddrV4,
+    target_addr: SocketAddr,
     port_offset: u16,
     flow: UdpFlow,
 
@@ -64,8 +64,12 @@ struct UdpClientKey {
 }
 
 impl UdpClientKey {
-    pub async fn create_socket(&self, special_lan: bool) -> std::io::Result<UdpSocket> {
-        LanAddress::udp_socket(special_lan, self.source_addr, self.tunnel_id).await
+    pub async fn create_socket(
+        &self,
+        special_lan: bool,
+        target_addr: SocketAddr,
+    ) -> std::io::Result<UdpSocket> {
+        LanAddress::udp_socket(special_lan, self.source_addr, target_addr, self.tunnel_id).await
     }
 }
 
@@ -173,12 +177,7 @@ impl UdpClients {
             return None;
         }
 
-        let SocketAddr::V4(source) = packet.from else {
-            udp_errors().origin_source_not_ip4.inc();
-            return None;
-        };
-
-        if source != client.target_addr {
+        if packet.from != client.target_addr {
             udp_errors().origin_reject_addr_differ.inc();
             return None;
         }
@@ -271,13 +270,10 @@ impl UdpClients {
             return;
         };
 
-        let SocketAddr::V4(target_addr) = target_addr else {
-            return;
-        };
+        let special_lan = matches!(target_addr, SocketAddr::V4(addr) if addr.ip().is_loopback())
+            && origin.proxy_protocol.is_none();
 
-        let special_lan = target_addr.ip().is_loopback() && origin.proxy_protocol.is_none();
-
-        let socket = match key.create_socket(special_lan).await {
+        let socket = match key.create_socket(special_lan, target_addr).await {
             Ok(socket) => Arc::new(socket),
             Err(error) => {
                 tracing::error!(?error, "failed to create socket");

--- a/packages/agent_core/tests/udp_tunnel_integration.rs
+++ b/packages/agent_core/tests/udp_tunnel_integration.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::{IpAddr, Ipv4Addr, SocketAddrV4},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     num::NonZeroU64,
     sync::Arc,
     time::{Duration, Instant},
@@ -159,6 +159,96 @@ async fn encapsulated_udp_tunnel_relays_in_both_directions_and_recovers_same_flo
     assert_eq!(encap_source_2, channel_addr);
     assert_eq!(encap_flow_2, flow.flip());
     assert_eq!(encap_payload_2, tunnel_reply_2);
+}
+
+#[tokio::test]
+async fn encapsulated_udp_tunnel_supports_ipv6_origin_addresses() {
+    let tunnel_server = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind tunnel server");
+    let origin_server = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+        .await
+        .expect("bind origin server");
+
+    let tunnel_addr = tunnel_server.local_addr().expect("tunnel addr");
+    let origin_addr = origin_server.local_addr().expect("origin addr");
+
+    let lookup = Arc::new(OriginLookup::default());
+    lookup
+        .update(std::iter::once(OriginResource {
+            tunnel_id: 42,
+            proto: PortProto::Udp,
+            target: OriginTarget::Port {
+                ip: OriginIp::IpAddress(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+                port: origin_addr.port(),
+            },
+            port_count: 0,
+            proxy_protocol: None,
+        }))
+        .await;
+
+    let stats = AgentStats::new();
+    let mut udp_clients = UdpClients::new(
+        UdpSettings::default(),
+        lookup,
+        Packets::new(64),
+        stats.clone(),
+    );
+    let mut udp_channel = UdpChannel::new(Packets::new(64))
+        .await
+        .expect("create udp channel");
+
+    udp_channel
+        .update_session(UdpChannelDetails {
+            tunnel_addr,
+            token: Arc::new(b"test-session-token".to_vec()),
+        })
+        .await;
+
+    let (token_len, channel_addr, token_bytes) = recv_from_socket(&tunnel_server).await;
+    assert_eq!(&token_bytes[..token_len], b"test-session-token");
+
+    tunnel_server
+        .send_to(&UDP_CHANNEL_ESTABLISH_ID.to_be_bytes(), channel_addr)
+        .await
+        .expect("send establish ack");
+
+    let flow = test_flow();
+    let origin_payload = b"packet to ipv6 origin";
+    send_tunneled_packet(&tunnel_server, channel_addr, flow, origin_payload).await;
+
+    let (recv_flow, recv_packet) = timeout(TEST_TIMEOUT, udp_channel.recv())
+        .await
+        .expect("recv tunneled packet");
+    assert_eq!(recv_flow, flow);
+    udp_clients
+        .handle_tunneled_packet(1_000, recv_flow, recv_packet)
+        .await;
+
+    let (origin_len, virtual_addr, origin_bytes) = recv_from_socket(&origin_server).await;
+    assert_eq!(&origin_bytes[..origin_len], origin_payload);
+    assert!(virtual_addr.is_ipv6());
+    assert_eq!(stats.active_udp(), 1);
+
+    let tunnel_reply = b"reply from ipv6 origin";
+    origin_server
+        .send_to(tunnel_reply, virtual_addr)
+        .await
+        .expect("origin send reply");
+
+    let reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+        .await
+        .expect("recv origin reply");
+    let (reply_flow, reply_packet) = udp_clients
+        .dispatch_origin_packet(2_000, reply)
+        .await
+        .expect("dispatch origin reply");
+    udp_channel.send(reply_flow, reply_packet).await;
+
+    let (encap_flow, encap_payload, encap_source) = recv_tunneled_packet(&tunnel_server).await;
+    assert_eq!(encap_source, channel_addr);
+    assert_eq!(encap_flow, flow.flip());
+    assert_eq!(encap_payload, tunnel_reply);
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Bind LAN UDP sockets for IPv4 or IPv6 targets
- Accept IPv6 origin packets in UDP client matching
- Add integration coverage for IPv6 origin tunneling