### PR TITLE
Trim Docker build to daemon package only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,6 @@ RUN cargo build --release --package=playit-agent-core
 # Build daemon
 COPY packages/playit-ipc packages/playit-ipc
 COPY packages/playitd packages/playitd
-COPY packages/playitd-tray packages/playitd-tray
-COPY packages/playitd-windows-setup packages/playitd-windows-setup
-COPY packages/playit-cli packages/playit-cli
 RUN cargo build --release --package playitd --bin playitd
 
 ########## RUNTIME CONTAINER ##########


### PR DESCRIPTION
## Summary
- Remove unused package copies from the Docker build context.
- Keep the image focused on building `playitd` and its IPC dependency only.
- Reduce Docker build overhead by avoiding tray, CLI, and Windows setup packages.

## Testing
- Not run (documentation/config-only change).
- Verified the Dockerfile diff removes only the extra `COPY` steps before the daemon build.