### PR TITLE
Allow authenticated users access to Windows pipe

### DIFF
--- a/packages/playitd/src/windows.rs
+++ b/packages/playitd/src/windows.rs
@@ -147,7 +147,7 @@ fn normalize_sid(sid: &str) -> Option<&str> {
 }
 
 fn pipe_security_sddl(user_sid: Option<&str>) -> String {
-    let mut sddl = String::from("D:P(A;;GA;;;SY)(A;;GA;;;BA)");
+    let mut sddl = String::from("D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;AU)");
     if let Some(user_sid) = user_sid.and_then(normalize_sid) {
         sddl.push_str("(A;;GA;;;");
         sddl.push_str(user_sid);
@@ -209,14 +209,14 @@ mod tests {
     use super::{normalize_sid, pipe_security_sddl};
 
     #[test]
-    fn pipe_sddl_allows_only_service_admins_and_installed_user() {
+    fn pipe_sddl_allows_service_admins_authenticated_users_and_installed_user() {
         let sddl = pipe_security_sddl(Some("S-1-5-21-1-2-3-1001"));
 
         assert!(sddl.contains("(A;;GA;;;SY)"));
         assert!(sddl.contains("(A;;GA;;;BA)"));
+        assert!(sddl.contains("(A;;GA;;;AU)"));
         assert!(sddl.contains("(A;;GA;;;S-1-5-21-1-2-3-1001)"));
         assert!(!sddl.contains("WD"));
-        assert!(!sddl.contains("AU"));
         assert!(!sddl.contains("BU"));
     }
 


### PR DESCRIPTION
## Summary
- Grant Windows pipe access to the `AU` authenticated users group in the pipe SDDL.
- Update the unit test to reflect the broader access policy.
- Keep access restricted from broader groups like `WD` and `BU` while preserving the installed user SID grant.

## Testing
- Not run (change is covered by existing unit tests).
- Verified the updated SDDL string includes `AU` alongside `SY` and `BA`.
- Verified the test assertion now checks for authenticated users access.