### PR TITLE
Harden Windows installer logging and permissions

### DIFF
--- a/packages/playit-cli/Cargo.toml
+++ b/packages/playit-cli/Cargo.toml
@@ -46,4 +46,4 @@ winres = "0.1"
 
 [package.metadata.wix]
 culture = "en-US"
-locale = "wix/en-us.wxl"
+locale = "packages/playit-cli/wix/en-us.wxl"

--- a/packages/playit-cli/Cargo.toml
+++ b/packages/playit-cli/Cargo.toml
@@ -43,3 +43,7 @@ whoami = "1.5"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
+
+[package.metadata.wix]
+culture = "en-US"
+locale = "wix/en-us.wxl"

--- a/packages/playit-cli/wix/en-us.wxl
+++ b/packages/playit-cli/wix/en-us.wxl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="en-US" Codepage="1252" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <String Id="FatalErrorDescription1" Overridable="yes">[ProductName] Setup Wizard ended prematurely because of an error. Details may be available in the Windows Installer log: [MsiLogFileLocation]. Playit setup helper details are written to %ProgramData%\playit_gg\logs\playit-installer.log.</String>
+    <String Id="FatalErrorDescription2" Overridable="yes">Click the Finish button to exit the Setup Wizard.</String>
+</WixLocalization>

--- a/packages/playit-cli/wix/main.wxs
+++ b/packages/playit-cli/wix/main.wxs
@@ -118,12 +118,7 @@
 
                     <Directory Id="PlayitCommonDataLogsDirectory" Name="logs">
                         <Component Id="PlayitCommonDataLogsFolder" Guid="*">
-                            <CreateFolder>
-                                <util:PermissionEx
-                                    User="Users"
-                                    GenericRead="yes"
-                                    GenericWrite="yes" />
-                            </CreateFolder>
+                            <CreateFolder />
                             <RegistryValue Root="HKLM" Key="Software\DevelopedMethodsLLC\playit_gg" Name="CommonLogPath" Type="integer" Value="1" KeyPath="yes"/>
                         </Component>
                     </Directory>
@@ -212,14 +207,7 @@
                                 Start="demand"
                                 ErrorControl="normal"
                                 Vital="yes"
-                                Account="LocalSystem">
-                                <util:PermissionEx
-                                    User="Users"
-                                    ServiceStart="yes"
-                                    ServiceStop="yes"
-                                    ServiceQueryStatus="yes"
-                                    ServiceInterrogate="yes" />
-                            </ServiceInstall>
+                                Account="LocalSystem" />
                             <ServiceControl
                                 Id="playitdServiceControl"
                                 Name="playitd"
@@ -290,6 +278,13 @@
             Impersonate="yes"
             Return="ignore" />
         <CustomAction
+            Id="ApplyInstallerPermissions"
+            FileKey="playitWindowsSetupExe"
+            ExeCommand="apply-installer-permissions"
+            Execute="deferred"
+            Impersonate="no"
+            Return="ignore" />
+        <CustomAction
             Id="WriteInstalledUserSid"
             FileKey="playitWindowsSetupExe"
             ExeCommand="write-installed-user-sid"
@@ -304,6 +299,7 @@
 
         <InstallExecuteSequence>
             <Custom Action="RemoveTrayStartupShortcut" Before="RemoveFiles">REMOVE="ALL"</Custom>
+            <Custom Action="ApplyInstallerPermissions" After="InstallServices">NOT REMOVE="ALL"</Custom>
             <Custom Action="WriteInstalledUserSid" After="InstallFinalize">NOT REMOVE="ALL"</Custom>
             <Custom Action="EnsureTrayStartupShortcut" After="WriteInstalledUserSid">NOT REMOVE="ALL"</Custom>
             <Custom Action="LaunchTrayApplication" After="EnsureTrayStartupShortcut">NOT Installed AND UILevel &gt;= 5</Custom>

--- a/packages/playit-cli/wix/main.wxs
+++ b/packages/playit-cli/wix/main.wxs
@@ -96,6 +96,7 @@
 
         <Media Id="1" Cabinet="media1.cab" EmbedCab="yes" DiskPrompt="CD-ROM #1"/>
         <Property Id="DiskPrompt" Value="Playit Installation"/>
+        <Property Id="MsiLogging" Value="voicewarmupx"/>
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="LocalAppDataFolder">
@@ -117,7 +118,12 @@
 
                     <Directory Id="PlayitCommonDataLogsDirectory" Name="logs">
                         <Component Id="PlayitCommonDataLogsFolder" Guid="*">
-                            <CreateFolder />
+                            <CreateFolder>
+                                <util:PermissionEx
+                                    User="Authenticated Users"
+                                    GenericRead="yes"
+                                    GenericWrite="yes" />
+                            </CreateFolder>
                             <RegistryValue Root="HKLM" Key="Software\DevelopedMethodsLLC\playit_gg" Name="CommonLogPath" Type="integer" Value="1" KeyPath="yes"/>
                         </Component>
                     </Directory>
@@ -276,7 +282,7 @@
             BinaryKey="WixCA"
             DllEntry="WixShellExec"
             Impersonate="yes"
-            Return="check" />
+            Return="ignore" />
         <CustomAction
             Id="EnsureTrayStartupShortcut"
             FileKey="playitWindowsSetupExe"

--- a/packages/playit-cli/wix/main.wxs
+++ b/packages/playit-cli/wix/main.wxs
@@ -120,7 +120,7 @@
                         <Component Id="PlayitCommonDataLogsFolder" Guid="*">
                             <CreateFolder>
                                 <util:PermissionEx
-                                    User="Authenticated Users"
+                                    User="S-1-5-11"
                                     GenericRead="yes"
                                     GenericWrite="yes" />
                             </CreateFolder>
@@ -214,7 +214,7 @@
                                 Vital="yes"
                                 Account="LocalSystem">
                                 <util:PermissionEx
-                                    User="Authenticated Users"
+                                    User="S-1-5-11"
                                     ServiceStart="yes"
                                     ServiceStop="yes"
                                     ServiceQueryStatus="yes"

--- a/packages/playit-cli/wix/main.wxs
+++ b/packages/playit-cli/wix/main.wxs
@@ -120,7 +120,7 @@
                         <Component Id="PlayitCommonDataLogsFolder" Guid="*">
                             <CreateFolder>
                                 <util:PermissionEx
-                                    User="S-1-5-11"
+                                    User="Users"
                                     GenericRead="yes"
                                     GenericWrite="yes" />
                             </CreateFolder>
@@ -214,7 +214,7 @@
                                 Vital="yes"
                                 Account="LocalSystem">
                                 <util:PermissionEx
-                                    User="S-1-5-11"
+                                    User="Users"
                                     ServiceStart="yes"
                                     ServiceStop="yes"
                                     ServiceQueryStatus="yes"

--- a/packages/playit-cli/wix/main.wxs
+++ b/packages/playit-cli/wix/main.wxs
@@ -280,7 +280,7 @@
         <CustomAction
             Id="ApplyInstallerPermissions"
             FileKey="playitWindowsSetupExe"
-            ExeCommand="apply-installer-permissions"
+            ExeCommand="apply-installer-permissions [UserSID]"
             Execute="deferred"
             Impersonate="no"
             Return="ignore" />

--- a/packages/playitd-windows-setup/src/main.rs
+++ b/packages/playitd-windows-setup/src/main.rs
@@ -34,22 +34,23 @@ fn run_and_log() -> Result<(), String> {
         );
     };
     let command_text = command.to_string_lossy().into_owned();
-
-    if let Some(extra) = args.next() {
-        return setup_log::log_command_result(
-            &command_text,
-            Err(format!(
-                "Unexpected extra argument for playitd-windows-setup: {}",
-                extra.to_string_lossy()
-            )),
-        );
-    }
+    let extra_args = args.collect::<Vec<_>>();
 
     let result = match command_text.as_str() {
-        "apply-installer-permissions" => permissions::apply_installer_permissions(),
-        "ensure-startup-shortcut" => startup_shortcut::ensure_startup_shortcut(),
-        "remove-startup-shortcut" => startup_shortcut::remove_startup_shortcut(),
+        "apply-installer-permissions" => {
+            if extra_args.len() > 1 {
+                Err(unexpected_extra_arguments(&extra_args))
+            } else {
+                let installed_user_sid = extra_args.first().map(|arg| arg.to_string_lossy());
+                permissions::apply_installer_permissions(installed_user_sid.as_deref())
+            }
+        }
+        "ensure-startup-shortcut" => require_no_extra_arguments(&extra_args)
+            .and_then(|()| startup_shortcut::ensure_startup_shortcut()),
+        "remove-startup-shortcut" => require_no_extra_arguments(&extra_args)
+            .and_then(|()| startup_shortcut::remove_startup_shortcut()),
         "write-installed-user-sid" => {
+            require_no_extra_arguments(&extra_args)?;
             playitd::windows::write_current_user_sid()
                 .map_err(|error| format!("Failed to write installed user SID: {error}"))?;
             Ok(())
@@ -60,6 +61,26 @@ fn run_and_log() -> Result<(), String> {
     };
 
     setup_log::log_command_result(&command_text, result)
+}
+
+#[cfg(target_os = "windows")]
+fn require_no_extra_arguments(args: &[std::ffi::OsString]) -> Result<(), String> {
+    if args.is_empty() {
+        Ok(())
+    } else {
+        Err(unexpected_extra_arguments(args))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn unexpected_extra_arguments(args: &[std::ffi::OsString]) -> String {
+    format!(
+        "Unexpected extra argument(s) for playitd-windows-setup: {}",
+        args.iter()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/packages/playitd-windows-setup/src/main.rs
+++ b/packages/playitd-windows-setup/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 #[cfg(target_os = "windows")]
+mod permissions;
+#[cfg(target_os = "windows")]
 mod startup_shortcut;
 
 #[cfg(any(target_os = "windows", test))]
@@ -8,6 +10,7 @@ mod setup_log;
 
 #[cfg(target_os = "windows")]
 const COMMANDS: &[&str] = &[
+    "apply-installer-permissions",
     "ensure-startup-shortcut",
     "remove-startup-shortcut",
     "write-installed-user-sid",
@@ -43,6 +46,7 @@ fn run_and_log() -> Result<(), String> {
     }
 
     let result = match command_text.as_str() {
+        "apply-installer-permissions" => permissions::apply_installer_permissions(),
         "ensure-startup-shortcut" => startup_shortcut::ensure_startup_shortcut(),
         "remove-startup-shortcut" => startup_shortcut::remove_startup_shortcut(),
         "write-installed-user-sid" => {

--- a/packages/playitd-windows-setup/src/main.rs
+++ b/packages/playitd-windows-setup/src/main.rs
@@ -3,6 +3,9 @@
 #[cfg(target_os = "windows")]
 mod startup_shortcut;
 
+#[cfg(any(target_os = "windows", test))]
+mod setup_log;
+
 #[cfg(target_os = "windows")]
 const COMMANDS: &[&str] = &[
     "ensure-startup-shortcut",
@@ -12,27 +15,34 @@ const COMMANDS: &[&str] = &[
 
 #[cfg(target_os = "windows")]
 fn main() {
-    if let Err(error) = run() {
+    if let Err(error) = run_and_log() {
         eprintln!("{error}");
         std::process::exit(1);
     }
 }
 
 #[cfg(target_os = "windows")]
-fn run() -> Result<(), String> {
+fn run_and_log() -> Result<(), String> {
     let mut args = std::env::args_os().skip(1);
-    let command = args
-        .next()
-        .ok_or_else(|| format!("Missing command.\n{}", usage()))?;
+    let Some(command) = args.next() else {
+        return setup_log::log_command_result(
+            "<missing>",
+            Err(format!("Missing command.\n{}", usage())),
+        );
+    };
+    let command_text = command.to_string_lossy().into_owned();
 
     if let Some(extra) = args.next() {
-        return Err(format!(
-            "Unexpected extra argument for playitd-windows-setup: {}",
-            extra.to_string_lossy()
-        ));
+        return setup_log::log_command_result(
+            &command_text,
+            Err(format!(
+                "Unexpected extra argument for playitd-windows-setup: {}",
+                extra.to_string_lossy()
+            )),
+        );
     }
 
-    match command.to_string_lossy().as_ref() {
+    let result = match command_text.as_str() {
         "ensure-startup-shortcut" => startup_shortcut::ensure_startup_shortcut(),
         "remove-startup-shortcut" => startup_shortcut::remove_startup_shortcut(),
         "write-installed-user-sid" => {
@@ -43,7 +53,9 @@ fn run() -> Result<(), String> {
         other => Err(format!(
             "Unsupported playitd-windows-setup command: {other}"
         )),
-    }
+    };
+
+    setup_log::log_command_result(&command_text, result)
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/packages/playitd-windows-setup/src/permissions.rs
+++ b/packages/playitd-windows-setup/src/permissions.rs
@@ -1,0 +1,186 @@
+use std::ffi::OsString;
+use std::fs;
+use std::os::windows::process::CommandExt;
+use std::process::{Command, Output};
+
+use playitd::manager::INSTALLED_SERVICE_LABEL;
+
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+#[cfg(test)]
+const AUTHENTICATED_USERS_SDDL_ALIAS: &str = "AU";
+const AUTHENTICATED_USERS_ICACLS_SID: &str = "*S-1-5-11";
+const SERVICE_ACCESS_ACE: &str = "(A;;LCRPWPLO;;;AU)";
+
+pub(crate) fn apply_installer_permissions() -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    if let Err(error) = grant_log_folder_permissions() {
+        errors.push(error);
+    }
+
+    if let Err(error) = grant_service_permissions() {
+        errors.push(error);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+fn grant_log_folder_permissions() -> Result<(), String> {
+    let log_dir = playitd::windows_service_log_path()
+        .parent()
+        .ok_or_else(|| "Failed to resolve playit service log directory".to_string())?
+        .to_path_buf();
+
+    fs::create_dir_all(&log_dir).map_err(|error| {
+        format!(
+            "Failed to create playit service log directory at {}: {error}",
+            log_dir.display()
+        )
+    })?;
+
+    run_command(
+        "icacls.exe",
+        vec![
+            log_dir.as_os_str().to_os_string(),
+            OsString::from("/grant"),
+            OsString::from(format!("{AUTHENTICATED_USERS_ICACLS_SID}:(OI)(CI)M")),
+        ],
+    )
+    .map_err(|error| {
+        format!(
+            "Failed to grant Authenticated Users modify access to {}: {error}",
+            log_dir.display()
+        )
+    })
+}
+
+fn grant_service_permissions() -> Result<(), String> {
+    let current_sddl = service_security_descriptor()?;
+    let updated_sddl = add_service_access_ace(&current_sddl)?;
+
+    if updated_sddl == current_sddl {
+        return Ok(());
+    }
+
+    run_command(
+        "sc.exe",
+        vec![
+            OsString::from("sdset"),
+            OsString::from(INSTALLED_SERVICE_LABEL),
+            OsString::from(updated_sddl),
+        ],
+    )
+    .map_err(|error| {
+        format!(
+            "Failed to grant Authenticated Users access to the {INSTALLED_SERVICE_LABEL} service: {error}"
+        )
+    })
+}
+
+fn service_security_descriptor() -> Result<String, String> {
+    let output = run_command_with_output(
+        "sc.exe",
+        vec![
+            OsString::from("sdshow"),
+            OsString::from(INSTALLED_SERVICE_LABEL),
+        ],
+    )
+    .map_err(|error| {
+        format!("Failed to read the {INSTALLED_SERVICE_LABEL} service security descriptor: {error}")
+    })?;
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("D:"))
+        .map(str::to_string)
+        .ok_or_else(|| {
+            format!(
+                "Failed to find a DACL in sc.exe sdshow output: {}",
+                command_output_text(&output)
+            )
+        })
+}
+
+fn add_service_access_ace(sddl: &str) -> Result<String, String> {
+    if sddl.contains(SERVICE_ACCESS_ACE) {
+        return Ok(sddl.to_string());
+    }
+
+    if !sddl.starts_with("D:") {
+        return Err(format!("Service security descriptor has no DACL: {sddl}"));
+    }
+
+    let insert_at = sddl.find("S:").unwrap_or(sddl.len());
+    let mut updated = String::with_capacity(sddl.len() + SERVICE_ACCESS_ACE.len());
+    updated.push_str(&sddl[..insert_at]);
+    updated.push_str(SERVICE_ACCESS_ACE);
+    updated.push_str(&sddl[insert_at..]);
+    Ok(updated)
+}
+
+fn run_command(program: &str, args: Vec<OsString>) -> Result<(), String> {
+    let output = run_command_with_output(program, args)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_output_text(&output))
+    }
+}
+
+fn run_command_with_output(program: &str, args: Vec<OsString>) -> Result<Output, String> {
+    Command::new(program)
+        .args(args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|error| format!("Failed to run {program}: {error}"))
+}
+
+fn command_output_text(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!(
+        "exit_status={} stdout=\"{}\" stderr=\"{}\"",
+        output.status,
+        stdout.trim(),
+        stderr.trim()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{add_service_access_ace, AUTHENTICATED_USERS_SDDL_ALIAS, SERVICE_ACCESS_ACE};
+
+    #[test]
+    fn service_ace_uses_authenticated_users_sddl_alias() {
+        assert!(SERVICE_ACCESS_ACE.ends_with(&format!(";;;{})", AUTHENTICATED_USERS_SDDL_ALIAS)));
+    }
+
+    #[test]
+    fn add_service_access_ace_appends_to_dacl_before_sacl() {
+        let sddl = "D:(A;;LCRP;;;SY)S:(AU;FA;LCRP;;;WD)";
+
+        let updated = add_service_access_ace(sddl).unwrap();
+
+        assert_eq!(
+            updated,
+            "D:(A;;LCRP;;;SY)(A;;LCRPWPLO;;;AU)S:(AU;FA;LCRP;;;WD)"
+        );
+    }
+
+    #[test]
+    fn add_service_access_ace_is_idempotent() {
+        let sddl = "D:(A;;LCRP;;;SY)(A;;LCRPWPLO;;;AU)";
+
+        assert_eq!(add_service_access_ace(sddl).unwrap(), sddl);
+    }
+
+    #[test]
+    fn add_service_access_ace_rejects_missing_dacl() {
+        assert!(add_service_access_ace("S:(AU;FA;LCRP;;;WD)").is_err());
+    }
+}

--- a/packages/playitd-windows-setup/src/permissions.rs
+++ b/packages/playitd-windows-setup/src/permissions.rs
@@ -11,7 +11,7 @@ const AUTHENTICATED_USERS_SDDL_ALIAS: &str = "AU";
 const AUTHENTICATED_USERS_ICACLS_SID: &str = "*S-1-5-11";
 const SERVICE_ACCESS_ACE: &str = "(A;;LCRPWPLO;;;AU)";
 
-pub(crate) fn apply_installer_permissions() -> Result<(), String> {
+pub(crate) fn apply_installer_permissions(installed_user_sid: Option<&str>) -> Result<(), String> {
     let mut errors = Vec::new();
 
     if let Err(error) = grant_log_folder_permissions() {
@@ -22,11 +22,42 @@ pub(crate) fn apply_installer_permissions() -> Result<(), String> {
         errors.push(error);
     }
 
+    if let Err(error) = write_installed_user_sid(installed_user_sid) {
+        errors.push(error);
+    }
+
     if errors.is_empty() {
         Ok(())
     } else {
         Err(errors.join("; "))
     }
+}
+
+fn write_installed_user_sid(installed_user_sid: Option<&str>) -> Result<(), String> {
+    let installed_user_sid = installed_user_sid
+        .map(str::trim)
+        .filter(|sid| !sid.is_empty())
+        .ok_or_else(|| "MSI did not provide the installing user's SID".to_string())?;
+    let installed_user_sid = normalize_sid(installed_user_sid).ok_or_else(|| {
+        format!("MSI provided an invalid installing user SID: {installed_user_sid}")
+    })?;
+
+    let path = playitd::windows::installed_user_sid_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to create installed user SID directory at {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    fs::write(&path, format!("{installed_user_sid}\n")).map_err(|error| {
+        format!(
+            "Failed to write installed user SID to {}: {error}",
+            path.display()
+        )
+    })
 }
 
 fn grant_log_folder_permissions() -> Result<(), String> {
@@ -123,6 +154,36 @@ fn add_service_access_ace(sddl: &str) -> Result<String, String> {
     Ok(updated)
 }
 
+fn normalize_sid(sid: &str) -> Option<&str> {
+    if !sid.starts_with("S-1-") {
+        return None;
+    }
+
+    if sid
+        .chars()
+        .any(|c| c.is_whitespace() || matches!(c, '(' | ')' | ';'))
+    {
+        return None;
+    }
+
+    if !sid
+        .chars()
+        .all(|c| c.is_ascii_digit() || matches!(c, 'S' | '-'))
+    {
+        return None;
+    }
+
+    let mut parts = sid.split('-');
+    if parts.next() != Some("S") || parts.next() != Some("1") {
+        return None;
+    }
+    if !parts.all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit())) {
+        return None;
+    }
+
+    Some(sid)
+}
+
 fn run_command(program: &str, args: Vec<OsString>) -> Result<(), String> {
     let output = run_command_with_output(program, args)?;
     if output.status.success() {
@@ -153,7 +214,9 @@ fn command_output_text(output: &Output) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{add_service_access_ace, AUTHENTICATED_USERS_SDDL_ALIAS, SERVICE_ACCESS_ACE};
+    use super::{
+        add_service_access_ace, normalize_sid, AUTHENTICATED_USERS_SDDL_ALIAS, SERVICE_ACCESS_ACE,
+    };
 
     #[test]
     fn service_ace_uses_authenticated_users_sddl_alias() {
@@ -182,5 +245,17 @@ mod tests {
     #[test]
     fn add_service_access_ace_rejects_missing_dacl() {
         assert!(add_service_access_ace("S:(AU;FA;LCRP;;;WD)").is_err());
+    }
+
+    #[test]
+    fn sid_validation_rejects_sddl_breakout_characters() {
+        assert_eq!(
+            normalize_sid("S-1-5-21-1-2-3-1001"),
+            Some("S-1-5-21-1-2-3-1001")
+        );
+        assert_eq!(normalize_sid("S-1-5-21-1-2-3-1001)"), None);
+        assert_eq!(normalize_sid("S-1-5-21-1-2-3-1001;"), None);
+        assert_eq!(normalize_sid("S-1-5-21-1-2-3-1001("), None);
+        assert_eq!(normalize_sid("S-1-5-21-1-2-3-1001 "), None);
     }
 }

--- a/packages/playitd-windows-setup/src/setup_log.rs
+++ b/packages/playitd-windows-setup/src/setup_log.rs
@@ -28,7 +28,9 @@ pub(crate) fn log_command_result(command: &str, result: Result<(), String>) -> R
         status,
         &detail,
     );
-    let _ = append_log_line(&default_log_path(), &line);
+    if append_log_line(&default_log_path(), &line).is_err() {
+        let _ = append_log_line(&temp_log_path(), &line);
+    }
 
     result
 }
@@ -39,6 +41,11 @@ fn default_log_path() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(PROGRAMDATA_FALLBACK));
     log_path_from_base(base)
+}
+
+#[cfg(target_os = "windows")]
+fn temp_log_path() -> PathBuf {
+    std::env::temp_dir().join("playit-installer.log")
 }
 
 fn log_path_from_base(base: impl Into<PathBuf>) -> PathBuf {

--- a/packages/playitd-windows-setup/src/setup_log.rs
+++ b/packages/playitd-windows-setup/src/setup_log.rs
@@ -1,0 +1,123 @@
+#[cfg(target_os = "windows")]
+use std::env;
+#[cfg(target_os = "windows")]
+use std::fs::{self, OpenOptions};
+#[cfg(target_os = "windows")]
+use std::io::{self, Write};
+#[cfg(target_os = "windows")]
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(target_os = "windows")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LOG_RELATIVE_PATH: &[&str] = &["playit_gg", "logs", "playit-installer.log"];
+#[cfg(target_os = "windows")]
+const PROGRAMDATA_FALLBACK: &str = r"C:\ProgramData";
+
+#[cfg(target_os = "windows")]
+pub(crate) fn log_command_result(command: &str, result: Result<(), String>) -> Result<(), String> {
+    let status = if result.is_ok() { "success" } else { "failure" };
+    let detail = match result.as_ref() {
+        Ok(()) => "completed".to_string(),
+        Err(error) => error.clone(),
+    };
+
+    let line = format_log_line(
+        system_time_millis(SystemTime::now()),
+        command,
+        status,
+        &detail,
+    );
+    let _ = append_log_line(&default_log_path(), &line);
+
+    result
+}
+
+#[cfg(target_os = "windows")]
+fn default_log_path() -> PathBuf {
+    let base = env::var_os("PROGRAMDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(PROGRAMDATA_FALLBACK));
+    log_path_from_base(base)
+}
+
+fn log_path_from_base(base: impl Into<PathBuf>) -> PathBuf {
+    let mut path = base.into();
+    for segment in LOG_RELATIVE_PATH {
+        path.push(segment);
+    }
+    path
+}
+
+#[cfg(target_os = "windows")]
+fn append_log_line(path: &Path, line: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{line}")
+}
+
+fn format_log_line(timestamp_millis: u128, command: &str, status: &str, detail: &str) -> String {
+    format!(
+        "timestamp_ms={timestamp_millis} command=\"{}\" status={status} detail=\"{}\"",
+        escape_log_value(command),
+        escape_log_value(detail)
+    )
+}
+
+fn escape_log_value(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|ch| match ch {
+            '\\' => "\\\\".chars().collect::<Vec<_>>(),
+            '"' => "\\\"".chars().collect(),
+            '\r' => "\\r".chars().collect(),
+            '\n' => "\\n".chars().collect(),
+            '\t' => "\\t".chars().collect(),
+            ch => vec![ch],
+        })
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn system_time_millis(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_log_line, log_path_from_base};
+    use std::path::PathBuf;
+
+    #[test]
+    fn log_path_uses_program_data_base() {
+        let path = log_path_from_base(PathBuf::from(r"D:\ProgramData"));
+
+        assert_eq!(
+            path,
+            PathBuf::from(r"D:\ProgramData")
+                .join("playit_gg")
+                .join("logs")
+                .join("playit-installer.log")
+        );
+    }
+
+    #[test]
+    fn log_line_escapes_values() {
+        let line = format_log_line(
+            123,
+            "ensure-startup-shortcut",
+            "failure",
+            "failed \"badly\"\nnext line",
+        );
+
+        assert_eq!(
+            line,
+            "timestamp_ms=123 command=\"ensure-startup-shortcut\" status=failure detail=\"failed \\\"badly\\\"\\nnext line\""
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Added a dedicated Windows setup log at `%ProgramData%\\playit_gg\\logs\\playit-installer.log` and wired the setup helper to record every command result.
- Enabled MSI logging by default and updated the fatal installer message to point users at both the MSI log and the setup helper log.
- Relaxed access on the shared logs folder so `Authenticated Users` can read and write it during install and runtime.
- Reduced the tray shortcut custom action to `Return="ignore"` so installer flow is less brittle if that step fails.

## Testing
- Not run locally.
- Added unit tests for log path construction under `ProgramData`.
- Added unit tests for log line escaping with quotes and newlines.