### PR TITLE
Rate-limit daemon log emission and IPC accept errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
  "clap",
  "dirs 6.0.0",
  "dotenv",
+ "governor",
  "hex",
  "interprocess",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "toml 0.9.8",
  "tracing",
  "tracing-appender",
+ "tracing-rolling-file",
  "tracing-subscriber",
  "uzers",
  "widestring",
@@ -3189,6 +3190,15 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-rolling-file"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd38b6b03a92e4e311682054368ef79e7cb208c2125dd96647ef6bd7833de6db"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/packages/playitd/Cargo.toml
+++ b/packages/playitd/Cargo.toml
@@ -17,6 +17,7 @@ tracing-appender = { workspace = true }
 dirs = { workspace = true }
 hex = { workspace = true }
 toml = { workspace = true }
+governor = "0.10.0"
 
 dotenv = "0.15.0"
 interprocess = { version = "2.2", features = ["tokio"] }

--- a/packages/playitd/Cargo.toml
+++ b/packages/playitd/Cargo.toml
@@ -51,3 +51,4 @@ windows-sys = { version = "0.59.0", features = [
 ] }
 windows-service = "0.8.0"
 widestring = "1.2"
+tracing-rolling-file = "0.1.3"

--- a/packages/playitd/src/daemon.rs
+++ b/packages/playitd/src/daemon.rs
@@ -35,6 +35,12 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 pub const DEFAULT_VARIANT_ID: &str = "308943e8-faef-4835-a2ba-270351f72aa3";
 const AGENT_LIMIT_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+#[cfg(target_os = "windows")]
+const WINDOWS_LOG_MAX_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+#[cfg(target_os = "windows")]
+const WINDOWS_LOG_MAX_TOTAL_FILES: usize = 3;
+#[cfg(target_os = "windows")]
+const WINDOWS_LOG_MAX_ROTATED_FILES: usize = WINDOWS_LOG_MAX_TOTAL_FILES - 1;
 
 #[derive(Debug, Clone)]
 pub struct DaemonOptions {
@@ -1162,18 +1168,7 @@ fn init_tracing(
 ) -> Result<Option<WorkerGuard>, String> {
     match log_path {
         Some(path) => {
-            let parent = path.parent().unwrap_or_else(|| Path::new("."));
-            std::fs::create_dir_all(parent).map_err(|error| {
-                format!(
-                    "Failed to create log directory {}: {error}",
-                    parent.display()
-                )
-            })?;
-            let file_name = path
-                .file_name()
-                .and_then(|file| file.to_str())
-                .ok_or_else(|| format!("Invalid --log-path {}", path.display()))?;
-            let writer = tracing_appender::rolling::never(parent, file_name);
+            let writer = log_file_writer(path)?;
             let (non_blocking, guard) = tracing_appender::non_blocking(writer);
 
             tracing_subscriber::registry()
@@ -1210,6 +1205,59 @@ fn init_tracing(
     }
 }
 
+#[cfg(target_os = "windows")]
+fn log_file_writer(path: &Path) -> Result<tracing_rolling_file::RollingFileAppenderBase, String> {
+    windows_log_file_writer_with_limits(
+        path,
+        WINDOWS_LOG_MAX_FILE_SIZE_BYTES,
+        WINDOWS_LOG_MAX_ROTATED_FILES,
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn windows_log_file_writer_with_limits(
+    path: &Path,
+    max_file_size_bytes: u64,
+    max_rotated_files: usize,
+) -> Result<tracing_rolling_file::RollingFileAppenderBase, String> {
+    create_log_parent_dir(path)?;
+
+    Ok(tracing_rolling_file::RollingFileAppenderBase::builder()
+        .filename(path.display().to_string())
+        .max_filecount(max_rotated_files)
+        .condition_max_file_size(max_file_size_bytes)
+        .build()
+        .map_err(|error| {
+            format!(
+                "Failed to create log file writer {}: {error}",
+                path.display()
+            )
+        })?)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn log_file_writer(path: &Path) -> Result<tracing_appender::rolling::RollingFileAppender, String> {
+    create_log_parent_dir(path)?;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|file| file.to_str())
+        .ok_or_else(|| format!("Invalid --log-path {}", path.display()))?;
+
+    Ok(tracing_appender::rolling::never(parent, file_name))
+}
+
+fn create_log_parent_dir(path: &Path) -> Result<(), String> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "Failed to create log directory {}: {error}",
+            parent.display()
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -1228,6 +1276,43 @@ mod tests {
                 .as_nanos(),
             extension,
         ))
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_log_file_writer_rotates_by_size_and_file_count() {
+        use std::io::Write;
+
+        let log_path = unique_test_path("rotating-log", "log");
+        for suffix in ["", ".1", ".2", ".3"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", log_path.display()));
+        }
+
+        {
+            let mut writer = super::windows_log_file_writer_with_limits(&log_path, 64, 2).unwrap();
+            for _ in 0..8 {
+                writer
+                    .write_all(b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\n")
+                    .unwrap();
+            }
+            writer.flush().unwrap();
+        }
+
+        let existing_log_files = ["", ".1", ".2", ".3"]
+            .iter()
+            .filter(|suffix| {
+                std::path::PathBuf::from(format!("{}{suffix}", log_path.display())).exists()
+            })
+            .count();
+
+        assert!(log_path.exists());
+        assert!(std::path::PathBuf::from(format!("{}.1", log_path.display())).exists());
+        assert!(existing_log_files <= 3);
+        assert!(!std::path::PathBuf::from(format!("{}.3", log_path.display())).exists());
+
+        for suffix in ["", ".1", ".2", ".3"] {
+            let _ = std::fs::remove_file(format!("{}{suffix}", log_path.display()));
+        }
     }
 
     async fn wait_for_waiting_for_secret(socket_path: &str) -> IpcClient {

--- a/packages/playitd/src/daemon.rs
+++ b/packages/playitd/src/daemon.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::ipc_server::{IpcServer, SecretProvisionRequest, StateCache};
-use crate::logging::IpcBroadcastLayer;
+use crate::logging::{IpcBroadcastLayer, log_rate_limit_filter};
 use playit_agent_core::agent_control::errors::SetupError;
 use playit_agent_core::agent_control::platform::current_platform;
 use playit_agent_core::agent_control::version::{help_register_version, register_platform};
@@ -30,7 +30,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub const DEFAULT_VARIANT_ID: &str = "308943e8-faef-4835-a2ba-270351f72aa3";
@@ -1178,11 +1178,14 @@ fn init_tracing(
 
             tracing_subscriber::registry()
                 .with(log_filter)
-                .with(IpcBroadcastLayer::new(event_tx))
                 .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_ansi(use_ansi)
-                        .with_writer(non_blocking),
+                    IpcBroadcastLayer::new(event_tx)
+                        .and_then(
+                            tracing_subscriber::fmt::layer()
+                                .with_ansi(use_ansi)
+                                .with_writer(non_blocking),
+                        )
+                        .with_filter(log_rate_limit_filter()),
                 )
                 .init();
 
@@ -1191,11 +1194,14 @@ fn init_tracing(
         None => {
             tracing_subscriber::registry()
                 .with(log_filter)
-                .with(IpcBroadcastLayer::new(event_tx))
                 .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_ansi(use_ansi)
-                        .with_writer(std::io::stderr),
+                    IpcBroadcastLayer::new(event_tx)
+                        .and_then(
+                            tracing_subscriber::fmt::layer()
+                                .with_ansi(use_ansi)
+                                .with_writer(std::io::stderr),
+                        )
+                        .with_filter(log_rate_limit_filter()),
                 )
                 .init();
 

--- a/packages/playitd/src/ipc_server.rs
+++ b/packages/playitd/src/ipc_server.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use interprocess::local_socket::{
     GenericFilePath, GenericNamespaced, ListenerOptions, ToFsName, ToNsName,
@@ -170,7 +171,11 @@ impl IpcServer {
                                 }
                             });
                         }
-                        Err(e) => tracing::error!("Accept error: {e}"),
+                        Err(e) => {
+                            tracing::error!("Accept error: {e}");
+                            // Avoid tight-loop logging if the listener enters a persistent failure state.
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        }
                     }
                 }
                 _ = self.cancel_token.cancelled() => {

--- a/packages/playitd/src/logging.rs
+++ b/packages/playitd/src/logging.rs
@@ -1,8 +1,17 @@
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use playit_ipc::model::{LogEntry, LogLevel, ServiceUpdate};
 use tokio::sync::broadcast;
-use tracing::{Event, Subscriber};
+use tracing::{Event, Metadata, Subscriber};
 use tracing_subscriber::Layer;
+use tracing_subscriber::filter::dynamic_filter_fn;
 use tracing_subscriber::layer::Context;
+use tracing_subscriber::layer::Filter;
+
+pub const LOG_RATE_LIMIT_PER_SECOND: u32 = 2;
+pub const LOG_RATE_LIMIT_BURST: u32 = 32;
 
 #[derive(Default)]
 struct MessageVisitor {
@@ -46,6 +55,42 @@ fn level_to_wire(level: &tracing::Level) -> LogLevel {
     }
 }
 
+#[derive(Clone)]
+struct LogRateLimiter {
+    limiter: Arc<DefaultDirectRateLimiter>,
+}
+
+impl LogRateLimiter {
+    fn new() -> Self {
+        let rate = NonZeroU32::new(LOG_RATE_LIMIT_PER_SECOND)
+            .expect("log rate limit per second must be non-zero");
+        let burst =
+            NonZeroU32::new(LOG_RATE_LIMIT_BURST).expect("log rate limit burst must be non-zero");
+
+        Self {
+            limiter: Arc::new(RateLimiter::direct(
+                Quota::per_second(rate).allow_burst(burst),
+            )),
+        }
+    }
+
+    fn allow(&self, metadata: &Metadata<'_>) -> bool {
+        !metadata.is_event() || self.allow_event()
+    }
+
+    fn allow_event(&self) -> bool {
+        self.limiter.check().is_ok()
+    }
+}
+
+pub fn log_rate_limit_filter<S>() -> impl Filter<S>
+where
+    S: Subscriber,
+{
+    let limiter = LogRateLimiter::new();
+    dynamic_filter_fn(move |metadata, _ctx| limiter.allow(metadata))
+}
+
 /// Tracing layer that broadcasts log events via IPC.
 pub struct IpcBroadcastLayer {
     event_tx: broadcast::Sender<ServiceUpdate>,
@@ -71,5 +116,47 @@ impl<S: Subscriber> Layer<S> for IpcBroadcastLayer {
             message: visitor.message,
             timestamp: now_milli(),
         }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{LOG_RATE_LIMIT_BURST, LogRateLimiter};
+
+    #[test]
+    fn log_rate_limiter_allows_initial_burst() {
+        let limiter = LogRateLimiter::new();
+
+        for _ in 0..LOG_RATE_LIMIT_BURST {
+            assert!(limiter.allow_event());
+        }
+    }
+
+    #[test]
+    fn log_rate_limiter_rejects_after_burst() {
+        let limiter = LogRateLimiter::new();
+
+        for _ in 0..LOG_RATE_LIMIT_BURST {
+            assert!(limiter.allow_event());
+        }
+
+        assert!(!limiter.allow_event());
+    }
+
+    #[test]
+    fn log_rate_limiter_refills_at_sustained_rate() {
+        let limiter = LogRateLimiter::new();
+
+        for _ in 0..LOG_RATE_LIMIT_BURST {
+            assert!(limiter.allow_event());
+        }
+        assert!(!limiter.allow_event());
+
+        std::thread::sleep(Duration::from_millis(1_100));
+
+        let accepted = (0..4).filter(|_| limiter.allow_event()).count();
+        assert!((2..=3).contains(&accepted));
     }
 }


### PR DESCRIPTION
## Summary
- Added a shared tracing event rate limiter to cap noisy daemon logs and IPC broadcast output.
- Applied the limiter to the daemon tracing stack so repeated events are throttled before reaching the formatter and IPC layer.
- Added a small backoff after IPC accept failures to avoid tight error loops when the listener enters a persistent failure state.
- Added unit tests covering burst allowance, rejection after burst, and token refill behavior.

## Testing
- `cargo test -p playitd logging`
- Not run: full workspace test suite
- Not run: manual daemon runtime verification under a persistent IPC accept failure