### PR TITLE
Add RPM and AUR packaging support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,8 @@ jobs:
             artifact: playit-linux-amd64
             artifact_cli: playit-cli-linux-amd64
             dpkg_arch: amd64
+            rpm_arch: x86_64
+            aur_arch: x86_64
 
           - name: linux arm64
             os: ubuntu-latest
@@ -29,6 +31,8 @@ jobs:
             artifact: playit-linux-aarch64
             artifact_cli: playit-cli-linux-aarch64
             dpkg_arch: arm64
+            rpm_arch: aarch64
+            aur_arch: aarch64
 
           - name: linux arm7
             os: ubuntu-latest
@@ -36,6 +40,8 @@ jobs:
             artifact: playit-linux-armv7
             artifact_cli: playit-cli-linux-armv7
             dpkg_arch: armhf
+            rpm_arch: armv7hl
+            aur_arch: armv7h
 
           - name: linux 32bit
             os: ubuntu-latest
@@ -43,6 +49,8 @@ jobs:
             artifact: playit-linux-i686
             artifact_cli: playit-cli-linux-i686
             dpkg_arch: i386
+            rpm_arch: i686
+            aur_arch: i686
 
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -53,6 +61,13 @@ jobs:
         uses: bruceadams/get-release@v1.2.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install RPM packaging tools
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          sudo gem install --no-document fpm
 
       - name: build release
         uses: actions-rs/cargo@v1
@@ -81,6 +96,19 @@ jobs:
           asset_name: ${{ matrix.platform.artifact_cli }}
           asset_content_type: application/octet-stream
 
+      - name: Collect AUR inputs
+        shell: bash
+        run: |
+          mkdir -p ./target/aur-inputs
+          cp "./target/${{ matrix.platform.arch }}/release/playitd" "./target/aur-inputs/${{ matrix.platform.artifact }}"
+          cp "./target/${{ matrix.platform.arch }}/release/playit-cli" "./target/aur-inputs/${{ matrix.platform.artifact_cli }}"
+
+      - name: Upload AUR inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-aur-inputs-${{ matrix.platform.aur_arch }}
+          path: ./target/aur-inputs/*
+
       - name: Package .deb
         shell: bash
         run: 'bash ./build-scripts/package-linux-deb.sh "./target/${{ matrix.platform.arch }}/release/playit-cli" "./target/${{ matrix.platform.arch }}/release/playitd" ${{ matrix.platform.dpkg_arch }}'
@@ -94,6 +122,57 @@ jobs:
           asset_path: ./target/deb/playit_${{ matrix.platform.dpkg_arch }}.deb
           asset_name: playit_${{ matrix.platform.dpkg_arch }}.deb
           asset_content_type: application/octet-stream
+
+      - name: Package .rpm
+        shell: bash
+        run: 'bash ./build-scripts/package-linux-rpm.sh "./target/${{ matrix.platform.arch }}/release/playit-cli" "./target/${{ matrix.platform.arch }}/release/playitd" ${{ matrix.platform.rpm_arch }}'
+
+      - name: Upload .rpm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./target/rpm/playit_${{ matrix.platform.rpm_arch }}.rpm
+          asset_name: playit_${{ matrix.platform.rpm_arch }}.rpm
+          asset_content_type: application/x-rpm
+
+  build_arch_aur:
+    runs-on: ubuntu-latest
+    needs: [build_linux]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Download Linux release binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: linux-aur-inputs-*
+          merge-multiple: true
+          path: ./target/aur-inputs
+
+      - name: Generate AUR package files
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash ./build-scripts/package-arch-aur.sh "${VERSION}" ./target/aur-inputs
+          tar -C ./target/aur -czf ./target/playit-bin-PKGBUILD.tar.gz playit-bin
+
+      - name: Upload AUR package files
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./target/playit-bin-PKGBUILD.tar.gz
+          asset_name: playit-bin-PKGBUILD.tar.gz
+          asset_content_type: application/gzip
+
   build_windows:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.git
 sudo apt update
 ```
 
+### Installing on Fedora
+
+Download the RPM for your architecture from the latest GitHub release, then install it with `dnf`:
+
+```sh
+sudo dnf install ./playit_x86_64.rpm
+```
+
+Available RPM architectures are `x86_64`, `aarch64`, `armv7hl`, and `i686`.
+
+### Installing on Arch Linux
+
+Install the binary AUR package:
+
+```sh
+yay -S playit-bin
+```
+
+The generated `playit-bin` AUR package files are also attached to GitHub releases as `playit-bin-PKGBUILD.tar.gz` for maintainers and manual publishing.
+
 **Note**
 Please only use the playit program if you downloaded it from an offical source or are compiling and running from source.
 

--- a/build-scripts/download.sh
+++ b/build-scripts/download.sh
@@ -40,6 +40,13 @@ FILES=(
   playit_arm64.deb
   playit_armhf.deb
   playit_i386.deb
+
+  playit_x86_64.rpm
+  playit_aarch64.rpm
+  playit_armv7hl.rpm
+  playit_i686.rpm
+
+  playit-bin-PKGBUILD.tar.gz
 )
 
 BASE_URL="https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}"

--- a/build-scripts/package-arch-aur.sh
+++ b/build-scripts/package-arch-aur.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <version> <release-asset-dir>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_DIR="${SCRIPT_DIR}/.."
+ROOT_CARGO_FILE="${REPO_DIR}/Cargo.toml"
+CLI_CARGO_FILE="${REPO_DIR}/packages/playit-cli/Cargo.toml"
+AUR_DIR="${REPO_DIR}/target/aur/playit-bin"
+
+if [[ "$2" = /* ]]; then
+  RELEASE_ASSET_DIR="$2"
+else
+  RELEASE_ASSET_DIR="$(pwd)/$2"
+fi
+
+# shellcheck source=build-scripts/package-metadata.sh
+source "${SCRIPT_DIR}/package-metadata.sh"
+
+DESCRIPTION="$(package_metadata_cli_description "${CLI_CARGO_FILE}")"
+MAINTAINER="$(package_metadata_cli_author "${CLI_CARGO_FILE}")"
+WORKSPACE_VERSION="$(package_metadata_workspace_version "${ROOT_CARGO_FILE}")"
+
+if [[ "${VERSION}" != "${WORKSPACE_VERSION}" ]]; then
+  echo "warning: requested AUR version ${VERSION} does not match workspace version ${WORKSPACE_VERSION}" >&2
+fi
+
+sha256_file() {
+  local file="$1"
+  if [[ ! -f "${file}" ]]; then
+    echo "missing release asset: ${file}" >&2
+    exit 1
+  fi
+  sha256sum "${file}" | awk '{print $1}'
+}
+
+checksum_pair() {
+  local arch="$1"
+  printf "    '%s'\n    '%s'\n" \
+    "$(sha256_file "${RELEASE_ASSET_DIR}/playit-cli-linux-${arch}")" \
+    "$(sha256_file "${RELEASE_ASSET_DIR}/playit-linux-${arch}")"
+}
+
+rm -rf "${AUR_DIR}"
+mkdir -p "${AUR_DIR}"
+cp "${REPO_DIR}/linux/playit.service" "${AUR_DIR}/playit.service"
+cp "${REPO_DIR}/linux/logrotate.conf" "${AUR_DIR}/logrotate.conf"
+cp "${REPO_DIR}/LICENSE.txt" "${AUR_DIR}/LICENSE.txt"
+
+SERVICE_SHA="$(sha256_file "${AUR_DIR}/playit.service")"
+LOGROTATE_SHA="$(sha256_file "${AUR_DIR}/logrotate.conf")"
+LICENSE_SHA="$(sha256_file "${AUR_DIR}/LICENSE.txt")"
+AMD64_SUMS="$(checksum_pair amd64)"
+AARCH64_SUMS="$(checksum_pair aarch64)"
+ARMV7_SUMS="$(checksum_pair armv7)"
+I686_SUMS="$(checksum_pair i686)"
+
+cat > "${AUR_DIR}/PKGBUILD" <<EOF
+# Maintainer: ${MAINTAINER}
+pkgname=playit-bin
+pkgver=${VERSION}
+pkgrel=1
+pkgdesc='${DESCRIPTION}'
+arch=('x86_64' 'aarch64' 'armv7h' 'i686')
+url='https://github.com/playit-cloud/playit-agent'
+license=('BSD-2-Clause')
+depends=('logrotate')
+provides=('playit')
+conflicts=('playit')
+install="\${pkgname}.install"
+source=('playit.service' 'logrotate.conf' 'LICENSE.txt')
+source_x86_64=(
+    "playit-cli-linux-amd64-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-cli-linux-amd64"
+    "playit-linux-amd64-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-linux-amd64"
+)
+source_aarch64=(
+    "playit-cli-linux-aarch64-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-cli-linux-aarch64"
+    "playit-linux-aarch64-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-linux-aarch64"
+)
+source_armv7h=(
+    "playit-cli-linux-armv7-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-cli-linux-armv7"
+    "playit-linux-armv7-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-linux-armv7"
+)
+source_i686=(
+    "playit-cli-linux-i686-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-cli-linux-i686"
+    "playit-linux-i686-\${pkgver}::\${url}/releases/download/v\${pkgver}/playit-linux-i686"
+)
+sha256sums=(
+    '${SERVICE_SHA}'
+    '${LOGROTATE_SHA}'
+    '${LICENSE_SHA}'
+)
+sha256sums_x86_64=(
+${AMD64_SUMS}
+)
+sha256sums_aarch64=(
+${AARCH64_SUMS}
+)
+sha256sums_armv7h=(
+${ARMV7_SUMS}
+)
+sha256sums_i686=(
+${I686_SUMS}
+)
+
+package() {
+    local asset_arch
+    case "\${CARCH}" in
+        x86_64) asset_arch='amd64' ;;
+        aarch64) asset_arch='aarch64' ;;
+        armv7h) asset_arch='armv7' ;;
+        i686) asset_arch='i686' ;;
+        *) echo "unsupported architecture: \${CARCH}" >&2; return 1 ;;
+    esac
+
+    install -Dm755 "\${srcdir}/playit-cli-linux-\${asset_arch}-\${pkgver}" "\${pkgdir}/opt/playit/agent"
+    install -Dm755 "\${srcdir}/playit-linux-\${asset_arch}-\${pkgver}" "\${pkgdir}/opt/playit/playitd"
+    install -Dm644 "\${srcdir}/playit.service" "\${pkgdir}/usr/lib/systemd/system/playit.service"
+    install -Dm644 "\${srcdir}/logrotate.conf" "\${pkgdir}/etc/logrotate.d/playit"
+    install -Dm644 "\${srcdir}/LICENSE.txt" "\${pkgdir}/usr/share/licenses/\${pkgname}/LICENSE"
+
+    install -Dm755 /dev/stdin "\${pkgdir}/opt/playit/playit" <<'WRAPPER'
+#!/usr/bin/env bash
+/opt/playit/agent "\$@"
+WRAPPER
+}
+EOF
+
+cat > "${AUR_DIR}/playit-bin.install" <<'EOF'
+setup_playit_service() {
+  mkdir -p /usr/local/bin
+  ln -sfn /opt/playit/playit /usr/local/bin/playit
+  getent group playit >/dev/null || groupadd --system playit
+  install -d -o root -g playit -m 0750 /etc/playit
+  install -d -o root -g playit -m 0750 /var/log/playit
+  chown root:playit /etc/playit
+  chmod 0750 /etc/playit
+  if [[ -f /etc/playit/playit.toml ]]; then
+    chown root:root /etc/playit/playit.toml
+    chmod 0600 /etc/playit/playit.toml
+  fi
+  chown root:playit /var/log/playit
+  chmod 0750 /var/log/playit
+
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "systemctl is required to install playit" >&2
+    return 1
+  fi
+
+  LEGACY_UNIT="/etc/systemd/system/playit.service"
+  if [[ -f "${LEGACY_UNIT}" || -L "${LEGACY_UNIT}" ]]; then
+    BACKUP_UNIT="${LEGACY_UNIT}.pacman-bak.$(date -u +%Y%m%d%H%M%S)"
+    echo "Moving legacy systemd unit ${LEGACY_UNIT} to ${BACKUP_UNIT} because it shadows the packaged unit"
+    mv "${LEGACY_UNIT}" "${BACKUP_UNIT}"
+  elif [[ -e "${LEGACY_UNIT}" ]]; then
+    echo "Cannot install playit: ${LEGACY_UNIT} exists but is not a file or symlink" >&2
+    echo "Remove or rename it manually, then reinstall playit." >&2
+    return 1
+  fi
+
+  systemctl daemon-reload
+  systemctl enable playit
+  systemctl restart playit || systemctl start playit
+}
+
+post_install() {
+  setup_playit_service
+}
+
+post_upgrade() {
+  setup_playit_service
+}
+
+pre_remove() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop playit >/dev/null 2>&1 || true
+    systemctl disable playit >/dev/null 2>&1 || true
+  fi
+
+  if [[ -L "/usr/local/bin/playit" ]]; then
+    rm "/usr/local/bin/playit"
+  fi
+}
+
+post_remove() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || true
+  fi
+}
+EOF
+
+generate_srcinfo_fallback() {
+  cat > "${AUR_DIR}/.SRCINFO" <<EOF
+pkgbase = playit-bin
+	pkgdesc = ${DESCRIPTION}
+	pkgver = ${VERSION}
+	pkgrel = 1
+	url = https://github.com/playit-cloud/playit-agent
+	arch = x86_64
+	arch = aarch64
+	arch = armv7h
+	arch = i686
+	license = BSD-2-Clause
+	depends = logrotate
+	provides = playit
+	conflicts = playit
+	source = playit.service
+	source = logrotate.conf
+	source = LICENSE.txt
+	source_x86_64 = playit-cli-linux-amd64-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-cli-linux-amd64
+	source_x86_64 = playit-linux-amd64-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-linux-amd64
+	source_aarch64 = playit-cli-linux-aarch64-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-cli-linux-aarch64
+	source_aarch64 = playit-linux-aarch64-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-linux-aarch64
+	source_armv7h = playit-cli-linux-armv7-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-cli-linux-armv7
+	source_armv7h = playit-linux-armv7-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-linux-armv7
+	source_i686 = playit-cli-linux-i686-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-cli-linux-i686
+	source_i686 = playit-linux-i686-${VERSION}::https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}/playit-linux-i686
+	sha256sums = ${SERVICE_SHA}
+	sha256sums = ${LOGROTATE_SHA}
+	sha256sums = ${LICENSE_SHA}
+	sha256sums_x86_64 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-cli-linux-amd64")
+	sha256sums_x86_64 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-linux-amd64")
+	sha256sums_aarch64 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-cli-linux-aarch64")
+	sha256sums_aarch64 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-linux-aarch64")
+	sha256sums_armv7h = $(sha256_file "${RELEASE_ASSET_DIR}/playit-cli-linux-armv7")
+	sha256sums_armv7h = $(sha256_file "${RELEASE_ASSET_DIR}/playit-linux-armv7")
+	sha256sums_i686 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-cli-linux-i686")
+	sha256sums_i686 = $(sha256_file "${RELEASE_ASSET_DIR}/playit-linux-i686")
+
+pkgname = playit-bin
+	install = playit-bin.install
+EOF
+}
+
+(
+  cd "${AUR_DIR}"
+  if command -v makepkg >/dev/null 2>&1; then
+    makepkg --printsrcinfo > .SRCINFO
+  else
+    echo "makepkg not found; generating .SRCINFO without makepkg" >&2
+    generate_srcinfo_fallback
+  fi
+)

--- a/build-scripts/package-linux-deb.sh
+++ b/build-scripts/package-linux-deb.sh
@@ -1,8 +1,8 @@
-cargo install toml-cli
+#!/usr/bin/env bash
+set -euo pipefail
 
 START_DIR="$(pwd)"
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 if [[ $# -ne 2 && $# -ne 3 ]]; then
   echo "usage: $0 <playit-cli-binary> [playitd-binary] <deb-arch>" >&2
@@ -29,77 +29,42 @@ fi
 
 CLI_BIN="$(resolve_input_path "${CLI_SRC_PATH}")"
 DAEMON_BIN="$(resolve_input_path "${DAEMON_SRC_PATH}")"
-
-if [[ ! -f "${CLI_BIN}" ]]; then
-  echo "playit CLI binary not found: ${CLI_BIN}" >&2
-  exit 1
-fi
-
-if [[ ! -f "${DAEMON_BIN}" ]]; then
-  echo "playit daemon binary not found: ${DAEMON_BIN}" >&2
-  exit 1
-fi
-
 TEMP_DIR_NAME="temp-build-${DEB_ARCH}"
-
-# prepare temp build folder
-echo "PREPARE TEMP BUILD FOLDER"
-# shellcheck disable=SC2164
-cd "${SCRIPT_DIR}"
-rm -fr "${TEMP_DIR_NAME}"
-mkdir "${TEMP_DIR_NAME}"
-# shellcheck disable=SC2164
-cd "${TEMP_DIR_NAME}"
-
+DEB_PACKAGE="playit_${DEB_ARCH}"
+ROOT_CARGO_FILE="${SCRIPT_DIR}/../Cargo.toml"
+CLI_CARGO_FILE="${SCRIPT_DIR}/../packages/playit-cli/Cargo.toml"
 INSTALL_FOLDER="/opt/playit"
 
-ROOT_CARGO_FILE="${SCRIPT_DIR}/../Cargo.toml"
-CARGO_FILE="${SCRIPT_DIR}/../packages/playit-cli/Cargo.toml"
-VERSION=$(toml get "${ROOT_CARGO_FILE}" workspace.package.version | sed "s/\"//g")
+# shellcheck source=build-scripts/package-metadata.sh
+source "${SCRIPT_DIR}/package-metadata.sh"
 
-DEB_PACKAGE="playit_${DEB_ARCH}"
-# shellcheck disable=SC2164
-mkdir "${DEB_PACKAGE}" && cd "${DEB_PACKAGE}"
-WK_DIR=$(pwd)
+VERSION="$(package_metadata_workspace_version "${ROOT_CARGO_FILE}")"
+MAINTAINER="$(package_metadata_cli_author "${CLI_CARGO_FILE}")"
+DESCRIPTION="$(package_metadata_cli_description "${CLI_CARGO_FILE}")"
 
-# Copy over playit binary
-echo "PREPARE BINARY AND RUN SCRIPT"
-mkdir -p "${WK_DIR}${INSTALL_FOLDER}"
+echo "PREPARE TEMP BUILD FOLDER"
+cd "${SCRIPT_DIR}"
+rm -rf "${TEMP_DIR_NAME}"
+mkdir -p "${TEMP_DIR_NAME}"
 
-cp "${CLI_BIN}" "${WK_DIR}${INSTALL_FOLDER}/agent"
-cp "${DAEMON_BIN}" "${WK_DIR}${INSTALL_FOLDER}/playitd"
-chmod 0755 "${WK_DIR}${INSTALL_FOLDER}/agent" "${WK_DIR}${INSTALL_FOLDER}/playitd"
+WK_DIR="${SCRIPT_DIR}/${TEMP_DIR_NAME}/${DEB_PACKAGE}"
 
-# Create run script
-echo "#!/bin/bash
-/opt/playit/agent \$@
-" > "${WK_DIR}${INSTALL_FOLDER}/playit"
-chmod 0755 "${WK_DIR}${INSTALL_FOLDER}/playit"
+echo "PREPARE PACKAGE FILES"
+"${SCRIPT_DIR}/package-linux-stage.sh" "${CLI_BIN}" "${DAEMON_BIN}" "${WK_DIR}" "/lib/systemd/system"
 
-# Add systemd unit
-mkdir -p "${WK_DIR}/lib/systemd/system"
-cp "${SCRIPT_DIR}/../linux/playit.service" "${WK_DIR}/lib/systemd/system/playit.service"
-
-# Add logrotate config
-mkdir -p "${WK_DIR}/etc/logrotate.d"
-cp "${SCRIPT_DIR}/../linux/logrotate.conf" "${WK_DIR}/etc/logrotate.d/playit"
-
-# build control file
 echo "BUILD DEB CONFIG FILES"
-
-mkdir -p DEBIAN
-echo "
+mkdir -p "${WK_DIR}/DEBIAN"
+cat > "${WK_DIR}/DEBIAN/control" <<EOF
 Package: playit
 Version: ${VERSION}
 Architecture: ${DEB_ARCH}
-Maintainer: $(toml get "${CARGO_FILE}" 'package.authors[0]' | sed "s/\"//g")
-Description: $(toml get "${CARGO_FILE}" package.description | sed "s/\"//g")
+Maintainer: ${MAINTAINER}
+Description: ${DESCRIPTION}
 Depends: logrotate
-" > "${WK_DIR}/DEBIAN/control"
+EOF
 
-# setup script
-cat <<EOF > "${WK_DIR}/DEBIAN/postinst"
-#!/bin/bash
+cat > "${WK_DIR}/DEBIAN/postinst" <<EOF
+#!/usr/bin/env bash
 set -e
 
 mkdir -p /usr/local/bin
@@ -138,17 +103,14 @@ systemctl restart playit || systemctl start playit
 EOF
 chmod 0555 "${WK_DIR}/DEBIAN/postinst"
 
-# teardown script
-cat <<EOF > "${WK_DIR}/DEBIAN/prerm"
-#!/bin/bash
+cat > "${WK_DIR}/DEBIAN/prerm" <<'EOF'
+#!/usr/bin/env bash
 if [[ -L "/usr/local/bin/playit" ]]; then
-  rm "/usr/local/bin/playit";
+  rm "/usr/local/bin/playit"
 fi
 EOF
 chmod 0555 "${WK_DIR}/DEBIAN/prerm"
 
-# build package
-# shellcheck disable=SC2164
 cd "${SCRIPT_DIR}/${TEMP_DIR_NAME}"
 dpkg-deb --build -Zgzip --root-owner-group "${DEB_PACKAGE}"
 

--- a/build-scripts/package-linux-rpm.sh
+++ b/build-scripts/package-linux-rpm.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+START_DIR="$(pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+if [[ $# -ne 2 && $# -ne 3 ]]; then
+  echo "usage: $0 <playit-cli-binary> [playitd-binary] <rpm-arch>" >&2
+  exit 1
+fi
+
+if ! command -v fpm >/dev/null 2>&1; then
+  echo "fpm is required to build RPM packages" >&2
+  exit 1
+fi
+
+resolve_input_path() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${START_DIR}" "$1"
+  fi
+}
+
+CLI_SRC_PATH="$1"
+
+if [[ $# -eq 3 ]]; then
+  DAEMON_SRC_PATH="$2"
+  RPM_ARCH="$3"
+else
+  DAEMON_SRC_PATH="$(dirname "${CLI_SRC_PATH}")/playitd"
+  RPM_ARCH="$2"
+fi
+
+CLI_BIN="$(resolve_input_path "${CLI_SRC_PATH}")"
+DAEMON_BIN="$(resolve_input_path "${DAEMON_SRC_PATH}")"
+TEMP_DIR_NAME="temp-rpm-${RPM_ARCH}"
+ROOT_CARGO_FILE="${SCRIPT_DIR}/../Cargo.toml"
+CLI_CARGO_FILE="${SCRIPT_DIR}/../packages/playit-cli/Cargo.toml"
+STAGE_DIR="${SCRIPT_DIR}/${TEMP_DIR_NAME}/stage"
+SCRIPTLET_DIR="${SCRIPT_DIR}/${TEMP_DIR_NAME}/scriptlets"
+OUTPUT_DIR="${SCRIPT_DIR}/../target/rpm"
+
+# shellcheck source=build-scripts/package-metadata.sh
+source "${SCRIPT_DIR}/package-metadata.sh"
+
+VERSION="$(package_metadata_workspace_version "${ROOT_CARGO_FILE}")"
+MAINTAINER="$(package_metadata_cli_author "${CLI_CARGO_FILE}")"
+DESCRIPTION="$(package_metadata_cli_description "${CLI_CARGO_FILE}")"
+
+rm -rf "${SCRIPT_DIR:?}/${TEMP_DIR_NAME}"
+mkdir -p "${SCRIPTLET_DIR}" "${OUTPUT_DIR}"
+
+"${SCRIPT_DIR}/package-linux-stage.sh" "${CLI_BIN}" "${DAEMON_BIN}" "${STAGE_DIR}" "/usr/lib/systemd/system"
+mkdir -p "${STAGE_DIR}/usr/share/licenses/playit"
+cp "${SCRIPT_DIR}/../LICENSE.txt" "${STAGE_DIR}/usr/share/licenses/playit/LICENSE.txt"
+
+cat > "${SCRIPTLET_DIR}/postinst" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+mkdir -p /usr/local/bin
+ln -sfn /opt/playit/playit /usr/local/bin/playit
+getent group playit >/dev/null || groupadd --system playit
+install -d -o root -g playit -m 0750 /etc/playit
+install -d -o root -g playit -m 0750 /var/log/playit
+chown root:playit /etc/playit
+chmod 0750 /etc/playit
+if [[ -f /etc/playit/playit.toml ]]; then
+  chown root:root /etc/playit/playit.toml
+  chmod 0600 /etc/playit/playit.toml
+fi
+chown root:playit /var/log/playit
+chmod 0750 /var/log/playit
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl is required to install playit" >&2
+  exit 1
+fi
+
+LEGACY_UNIT="/etc/systemd/system/playit.service"
+if [[ -f "${LEGACY_UNIT}" || -L "${LEGACY_UNIT}" ]]; then
+  BACKUP_UNIT="${LEGACY_UNIT}.rpm-bak.$(date -u +%Y%m%d%H%M%S)"
+  echo "Moving legacy systemd unit ${LEGACY_UNIT} to ${BACKUP_UNIT} because it shadows the packaged unit"
+  mv "${LEGACY_UNIT}" "${BACKUP_UNIT}"
+elif [[ -e "${LEGACY_UNIT}" ]]; then
+  echo "Cannot install playit: ${LEGACY_UNIT} exists but is not a file or symlink" >&2
+  echo "Remove or rename it manually, then reinstall playit." >&2
+  exit 1
+fi
+
+systemctl daemon-reload
+systemctl enable playit
+systemctl restart playit || systemctl start playit
+EOF
+
+cat > "${SCRIPTLET_DIR}/preun" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+if [[ "$1" -eq 0 ]]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop playit >/dev/null 2>&1 || true
+    systemctl disable playit >/dev/null 2>&1 || true
+  fi
+
+  if [[ -L "/usr/local/bin/playit" ]]; then
+    rm "/usr/local/bin/playit"
+  fi
+fi
+EOF
+
+cat > "${SCRIPTLET_DIR}/postun" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || true
+fi
+EOF
+
+chmod 0755 "${SCRIPTLET_DIR}/postinst" "${SCRIPTLET_DIR}/preun" "${SCRIPTLET_DIR}/postun"
+
+rm -f "${OUTPUT_DIR}/playit_${RPM_ARCH}.rpm"
+fpm \
+  -s dir \
+  -t rpm \
+  -C "${STAGE_DIR}" \
+  -n playit \
+  -v "${VERSION}" \
+  --iteration 1 \
+  --architecture "${RPM_ARCH}" \
+  --description "${DESCRIPTION}" \
+  --maintainer "${MAINTAINER}" \
+  --url "https://github.com/playit-cloud/playit-agent" \
+  --license "BSD-2-Clause" \
+  --depends logrotate \
+  --rpm-user root \
+  --rpm-group root \
+  --after-install "${SCRIPTLET_DIR}/postinst" \
+  --before-remove "${SCRIPTLET_DIR}/preun" \
+  --after-remove "${SCRIPTLET_DIR}/postun" \
+  --package "${OUTPUT_DIR}/playit_${RPM_ARCH}.rpm" \
+  .

--- a/build-scripts/package-linux-stage.sh
+++ b/build-scripts/package-linux-stage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 022
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <playit-cli-binary> <playitd-binary> <stage-dir> <systemd-unit-dir>" >&2
+  exit 1
+fi
+
+CLI_BIN="$1"
+DAEMON_BIN="$2"
+STAGE_DIR="$3"
+SYSTEMD_UNIT_DIR="$4"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_DIR="${SCRIPT_DIR}/.."
+INSTALL_FOLDER="/opt/playit"
+
+if [[ ! -f "${CLI_BIN}" ]]; then
+  echo "playit CLI binary not found: ${CLI_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${DAEMON_BIN}" ]]; then
+  echo "playit daemon binary not found: ${DAEMON_BIN}" >&2
+  exit 1
+fi
+
+rm -rf "${STAGE_DIR}"
+mkdir -p "${STAGE_DIR}${INSTALL_FOLDER}"
+
+cp "${CLI_BIN}" "${STAGE_DIR}${INSTALL_FOLDER}/agent"
+cp "${DAEMON_BIN}" "${STAGE_DIR}${INSTALL_FOLDER}/playitd"
+chmod 0755 "${STAGE_DIR}${INSTALL_FOLDER}/agent" "${STAGE_DIR}${INSTALL_FOLDER}/playitd"
+
+cat > "${STAGE_DIR}${INSTALL_FOLDER}/playit" <<'EOF'
+#!/usr/bin/env bash
+/opt/playit/agent "$@"
+EOF
+chmod 0755 "${STAGE_DIR}${INSTALL_FOLDER}/playit"
+
+mkdir -p "${STAGE_DIR}${SYSTEMD_UNIT_DIR}"
+cp "${REPO_DIR}/linux/playit.service" "${STAGE_DIR}${SYSTEMD_UNIT_DIR}/playit.service"
+
+mkdir -p "${STAGE_DIR}/etc/logrotate.d"
+cp "${REPO_DIR}/linux/logrotate.conf" "${STAGE_DIR}/etc/logrotate.d/playit"
+
+mkdir -p "${STAGE_DIR}/usr/share/doc/playit"
+cp "${REPO_DIR}/LICENSE.txt" "${STAGE_DIR}/usr/share/doc/playit/LICENSE.txt"

--- a/build-scripts/package-metadata.sh
+++ b/build-scripts/package-metadata.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+package_metadata_workspace_version() {
+  local root_cargo_file="$1"
+  if command -v toml >/dev/null 2>&1; then
+    toml get "${root_cargo_file}" workspace.package.version | sed 's/"//g'
+    return
+  fi
+
+  awk '
+    /^\[workspace\.package\]$/ { in_section = 1; next }
+    /^\[/ { in_section = 0 }
+    in_section && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' "${root_cargo_file}"
+}
+
+package_metadata_cli_author() {
+  local cli_cargo_file="$1"
+  if command -v toml >/dev/null 2>&1; then
+    toml get "${cli_cargo_file}" 'package.authors[0]' | sed 's/"//g'
+    return
+  fi
+
+  sed -nE 's/^authors = \["([^"]+)".*/\1/p' "${cli_cargo_file}" | head -n 1
+}
+
+package_metadata_cli_description() {
+  local cli_cargo_file="$1"
+  if command -v toml >/dev/null 2>&1; then
+    toml get "${cli_cargo_file}" package.description | sed 's/"//g'
+    return
+  fi
+
+  sed -nE 's/^description = "([^"]+)".*/\1/p' "${cli_cargo_file}" | head -n 1
+}


### PR DESCRIPTION
## Summary
- Add Fedora/RPM packaging to release builds, including per-architecture RPM assets for `x86_64`, `aarch64`, `armv7hl`, and `i686`.
- Add an Arch Linux AUR package generation flow and publish `playit-bin-PKGBUILD.tar.gz` as a release asset.
- Refactor Linux packaging into shared staging and metadata helpers to reduce duplication across `.deb`, `.rpm`, and AUR outputs.
- Update the README and release download script to cover the new package formats.

## Testing
- Not run: release workflow validation in GitHub Actions.
- Not run: RPM package install/upgrade/remove on Fedora.
- Not run: AUR package generation with `makepkg`/`namcap`.
- Not run: Debian packaging regression check after the shared staging refactor.