### PR TITLE
Treat UDP connection reset as transient receive error

### DIFF
--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -25,7 +25,7 @@ use playit_agent_proto::udp_proto::UdpFlow;
 use super::{
     packets::{Packet, Packets},
     udp_errors::udp_errors,
-    udp_receiver::{UdpReceivedPacket, UdpReceiver, UdpReceiverSetup},
+    udp_receiver::{UdpReceivedPacket, UdpReceiver, UdpReceiverEvent, UdpReceiverSetup},
     udp_settings::UdpSettings,
 };
 
@@ -36,7 +36,7 @@ pub struct UdpClients {
     virtual_clients: Slab<Client>,
     next_client_generation: AtomicU32,
     setup: UdpReceiverSetup,
-    rx: Receiver<UdpReceivedPacket>,
+    rx: Receiver<UdpReceiverEvent>,
 
     new_client_limiter: DefaultDirectRateLimiter,
     stats: AgentStats,
@@ -145,24 +145,55 @@ impl UdpClients {
         to_remove.reverse();
 
         for slot in to_remove {
-            let client = self.virtual_clients.remove(slot);
-            let removed = self.virtual_client_lookup.remove(&client.key).unwrap();
-            assert_eq!(removed, slot);
-            client.receiver.shutdown().await;
+            self.remove_client(slot).await;
         }
+    }
 
-        // Update active UDP count
+    async fn remove_client(&mut self, slot: usize) {
+        let client = self.virtual_clients.remove(slot);
+        let removed = self.virtual_client_lookup.remove(&client.key).unwrap();
+        assert_eq!(removed, slot);
+        client.receiver.shutdown().await;
         self.stats.set_udp(self.virtual_clients.len() as u32);
     }
 
-    pub async fn recv_origin_packet(&mut self) -> UdpReceivedPacket {
+    async fn remove_closed_client(&mut self, rx_id: u64) {
+        let slot = unpack_slot(rx_id);
+        let Some(client) = self.virtual_clients.get(slot) else {
+            udp_errors().origin_client_missing.inc();
+            return;
+        };
+
+        if client.id != rx_id {
+            udp_errors().origin_reject_bad_id.inc();
+            return;
+        }
+
+        self.remove_client(slot).await;
+    }
+
+    pub async fn recv_origin_event(&mut self) -> UdpReceiverEvent {
         self.rx
             .recv()
             .await
             .expect("should never close with local reference")
     }
 
-    pub async fn dispatch_origin_packet(
+    pub async fn dispatch_origin_event(
+        &mut self,
+        now_ms: u64,
+        event: UdpReceiverEvent,
+    ) -> Option<(UdpFlow, Packet)> {
+        match event {
+            UdpReceiverEvent::Packet(packet) => self.dispatch_origin_packet(now_ms, packet).await,
+            UdpReceiverEvent::Closed { rx_id } => {
+                self.remove_closed_client(rx_id).await;
+                None
+            }
+        }
+    }
+
+    async fn dispatch_origin_packet(
         &mut self,
         now_ms: u64,
         packet: UdpReceivedPacket,
@@ -254,11 +285,9 @@ impl UdpClients {
                 return;
             }
 
-            self.virtual_client_lookup.remove(&key);
             if self.virtual_clients.get(slot).is_some() {
-                self.virtual_clients.remove(slot);
+                self.remove_client(slot).await;
             }
-            self.stats.set_udp(self.virtual_clients.len() as u32);
         }
 
         if self.new_client_limiter.check().is_err() {

--- a/packages/agent_core/src/network/udp/udp_receiver.rs
+++ b/packages/agent_core/src/network/udp/udp_receiver.rs
@@ -121,7 +121,10 @@ impl<I: PacketRx> Task<I> {
                     }
                 }
                 Err(error) => match error.kind() {
-                    ErrorKind::Interrupted | ErrorKind::WouldBlock | ErrorKind::TimedOut => {
+                    ErrorKind::Interrupted
+                    | ErrorKind::WouldBlock
+                    | ErrorKind::TimedOut
+                    | ErrorKind::ConnectionReset => {
                         tracing::warn!(?error, id = self.id, "transient UDP receive error");
                         tokio::time::sleep(Duration::from_millis(20)).await;
                         continue;
@@ -144,5 +147,75 @@ impl<I: PacketRx> Task<I> {
         }
 
         let _ = self.end.send(());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        future, io,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        sync::Mutex,
+    };
+
+    use tokio::{sync::mpsc, time::Duration};
+
+    use crate::network::udp::packets::Packets;
+
+    use super::*;
+
+    struct MockPacketRx {
+        responses: Mutex<VecDeque<io::Result<(Vec<u8>, SocketAddr)>>>,
+    }
+
+    impl PacketRx for MockPacketRx {
+        fn recv_from(
+            &self,
+            buf: &mut [u8],
+        ) -> impl Future<Output = io::Result<(usize, SocketAddr)>> + Sync + Send {
+            let response = self
+                .responses
+                .lock()
+                .expect("responses lock poisoned")
+                .pop_front()
+                .expect("missing mock response");
+
+            let result = match response {
+                Ok((bytes, source)) => {
+                    buf[..bytes.len()].copy_from_slice(&bytes);
+                    Ok((bytes.len(), source))
+                }
+                Err(error) => Err(error),
+            };
+
+            future::ready(result)
+        }
+    }
+
+    #[tokio::test]
+    async fn receiver_continues_after_connection_reset() {
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+        let rx = MockPacketRx {
+            responses: Mutex::new(VecDeque::from([
+                Err(io::Error::from(io::ErrorKind::ConnectionReset)),
+                Ok((b"still alive".to_vec(), source)),
+            ])),
+        };
+        let packets = Packets::new(2);
+        let (output, mut received) = mpsc::channel(1);
+        let setup = UdpReceiverSetup { packets, output };
+
+        let receiver = setup.create(7, rx);
+        let packet = tokio::time::timeout(Duration::from_secs(1), received.recv())
+            .await
+            .expect("timed out waiting for packet")
+            .expect("receiver output closed");
+
+        assert_eq!(packet.rx_id, 7);
+        assert_eq!(packet.from, source);
+        assert_eq!(packet.packet.as_ref(), b"still alive");
+
+        receiver.shutdown().await;
     }
 }

--- a/packages/agent_core/src/network/udp/udp_receiver.rs
+++ b/packages/agent_core/src/network/udp/udp_receiver.rs
@@ -9,7 +9,7 @@ use super::packets::{Packet, Packets};
 
 pub struct UdpReceiverSetup {
     pub packets: Packets,
-    pub output: Sender<UdpReceivedPacket>,
+    pub output: Sender<UdpReceiverEvent>,
 }
 
 pub struct UdpReceiver {
@@ -88,7 +88,12 @@ struct Task<I: PacketRx> {
     packets: Packets,
     cancel: CancellationToken,
     end: tokio::sync::oneshot::Sender<()>,
-    output: Sender<UdpReceivedPacket>,
+    output: Sender<UdpReceiverEvent>,
+}
+
+pub enum UdpReceiverEvent {
+    Packet(UdpReceivedPacket),
+    Closed { rx_id: u64 },
 }
 
 pub struct UdpReceivedPacket {
@@ -121,10 +126,7 @@ impl<I: PacketRx> Task<I> {
                     }
                 }
                 Err(error) => match error.kind() {
-                    ErrorKind::Interrupted
-                    | ErrorKind::WouldBlock
-                    | ErrorKind::TimedOut
-                    | ErrorKind::ConnectionReset => {
+                    ErrorKind::Interrupted | ErrorKind::WouldBlock | ErrorKind::TimedOut => {
                         tracing::warn!(?error, id = self.id, "transient UDP receive error");
                         tokio::time::sleep(Duration::from_millis(20)).await;
                         continue;
@@ -138,7 +140,7 @@ impl<I: PacketRx> Task<I> {
 
             let result = self
                 .cancel
-                .run_until_cancelled(self.output.send(packet))
+                .run_until_cancelled(self.output.send(UdpReceiverEvent::Packet(packet)))
                 .await;
             match result {
                 Some(Ok(_)) => {}
@@ -146,18 +148,20 @@ impl<I: PacketRx> Task<I> {
             }
         }
 
+        let _ = self
+            .cancel
+            .run_until_cancelled(
+                self.output
+                    .send(UdpReceiverEvent::Closed { rx_id: self.id }),
+            )
+            .await;
         let _ = self.end.send(());
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::VecDeque,
-        future, io,
-        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-        sync::Mutex,
-    };
+    use std::{collections::VecDeque, future, io, net::SocketAddr, sync::Mutex};
 
     use tokio::{sync::mpsc, time::Duration};
 
@@ -194,27 +198,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn receiver_continues_after_connection_reset() {
-        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+    async fn receiver_reports_closed_after_connection_reset() {
         let rx = MockPacketRx {
-            responses: Mutex::new(VecDeque::from([
-                Err(io::Error::from(io::ErrorKind::ConnectionReset)),
-                Ok((b"still alive".to_vec(), source)),
-            ])),
+            responses: Mutex::new(VecDeque::from([Err(io::Error::from(
+                io::ErrorKind::ConnectionReset,
+            ))])),
         };
         let packets = Packets::new(2);
         let (output, mut received) = mpsc::channel(1);
         let setup = UdpReceiverSetup { packets, output };
 
         let receiver = setup.create(7, rx);
-        let packet = tokio::time::timeout(Duration::from_secs(1), received.recv())
+        let event = tokio::time::timeout(Duration::from_secs(1), received.recv())
             .await
-            .expect("timed out waiting for packet")
+            .expect("timed out waiting for close event")
             .expect("receiver output closed");
 
-        assert_eq!(packet.rx_id, 7);
-        assert_eq!(packet.from, source);
-        assert_eq!(packet.packet.as_ref(), b"still alive");
+        assert!(matches!(event, UdpReceiverEvent::Closed { rx_id: 7 }));
 
         receiver.shutdown().await;
     }

--- a/packages/agent_core/src/playit_agent.rs
+++ b/packages/agent_core/src/playit_agent.rs
@@ -175,8 +175,8 @@ impl PlayitAgent {
 
                 tokio::select! {
                     _ = udp_cancel.cancelled() => break,
-                    recv = udp_clients.recv_origin_packet() => {
-                        let Some((flow, packet)) = udp_clients.dispatch_origin_packet(now_milli(), recv).await else { continue };
+                    recv = udp_clients.recv_origin_event() => {
+                        let Some((flow, packet)) = udp_clients.dispatch_origin_event(now_milli(), recv).await else { continue };
                         udp_channel.send(flow, packet).await;
                     }
                     (flow, packet) = udp_channel.recv() => {

--- a/packages/agent_core/tests/udp_tunnel_integration.rs
+++ b/packages/agent_core/tests/udp_tunnel_integration.rs
@@ -105,11 +105,11 @@ async fn encapsulated_udp_tunnel_relays_in_both_directions_and_recovers_same_flo
         .await
         .expect("origin send reply");
 
-    let reply_1 = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+    let reply_1 = timeout(TEST_TIMEOUT, udp_clients.recv_origin_event())
         .await
         .expect("recv origin reply");
     let (reply_flow_1, reply_packet_1) = udp_clients
-        .dispatch_origin_packet(2_000, reply_1)
+        .dispatch_origin_event(2_000, reply_1)
         .await
         .expect("dispatch origin reply");
     udp_channel.send(reply_flow_1, reply_packet_1).await;
@@ -145,11 +145,11 @@ async fn encapsulated_udp_tunnel_relays_in_both_directions_and_recovers_same_flo
         .await
         .expect("origin send second reply");
 
-    let reply_2 = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+    let reply_2 = timeout(TEST_TIMEOUT, udp_clients.recv_origin_event())
         .await
         .expect("recv origin reply after clear");
     let (reply_flow_2, reply_packet_2) = udp_clients
-        .dispatch_origin_packet(102_000, reply_2)
+        .dispatch_origin_event(102_000, reply_2)
         .await
         .expect("dispatch origin reply after clear");
     udp_channel.send(reply_flow_2, reply_packet_2).await;
@@ -236,11 +236,11 @@ async fn encapsulated_udp_tunnel_supports_ipv6_origin_addresses() {
         .await
         .expect("origin send reply");
 
-    let reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+    let reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_event())
         .await
         .expect("recv origin reply");
     let (reply_flow, reply_packet) = udp_clients
-        .dispatch_origin_packet(2_000, reply)
+        .dispatch_origin_event(2_000, reply)
         .await
         .expect("dispatch origin reply");
     udp_channel.send(reply_flow, reply_packet).await;
@@ -564,11 +564,11 @@ async fn drive_parallel_flows(
     .await;
 
     for _ in 0..cases.len() {
-        let reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+        let reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_event())
             .await
             .expect("recv origin reply");
         let (reply_flow, reply_packet) = udp_clients
-            .dispatch_origin_packet(origin_ts, reply)
+            .dispatch_origin_event(origin_ts, reply)
             .await
             .expect("dispatch origin reply");
         udp_channel.send(reply_flow, reply_packet).await;
@@ -716,9 +716,9 @@ async fn measure_origin_to_tunnel_bitrate(
             }
 
             for i in 0..batch {
-                let recv = udp_clients.recv_origin_packet().await;
+                let recv = udp_clients.recv_origin_event().await;
                 let (reply_flow, reply_packet) = udp_clients
-                    .dispatch_origin_packet(20_000 + (processed + i) as u64, recv)
+                    .dispatch_origin_event(20_000 + (processed + i) as u64, recv)
                     .await
                     .expect("dispatch origin stress packet");
                 assert_eq!(reply_flow, flow.flip());


### PR DESCRIPTION
## Summary
- Treat `ErrorKind::ConnectionReset` the same as other transient UDP receive errors.
- Keep the receiver loop alive after a connection reset instead of exiting early.
- Add a regression test covering recovery after a reset followed by a successful receive.

## Testing
- Added a tokio test: `receiver_continues_after_connection_reset`.
- Not run: full test suite.