### PR TITLE
Fix log file ownership in postinstall

### DIFF
--- a/build-scripts/nfpm/postinstall.sh
+++ b/build-scripts/nfpm/postinstall.sh
@@ -159,11 +159,11 @@ mkdir -p /usr/local/bin /etc/playit /var/log/playit
 ln -sfn /opt/playit/playit /usr/local/bin/playit
 ln -sfn /opt/playit/playitd /usr/local/bin/playitd
 
-chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit /var/log/playit
+chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
+chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
 chmod 0750 /etc/playit /var/log/playit
 
 if [ -f /var/log/playit/playit.log ]; then
-  chown "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit/playit.log
   chmod 0640 /var/log/playit/playit.log
 fi
 

--- a/build-scripts/nfpm/postinstall.sh
+++ b/build-scripts/nfpm/postinstall.sh
@@ -162,6 +162,11 @@ ln -sfn /opt/playit/playitd /usr/local/bin/playitd
 chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit /var/log/playit
 chmod 0750 /etc/playit /var/log/playit
 
+if [ -f /var/log/playit/playit.log ]; then
+  chown "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit/playit.log
+  chmod 0640 /var/log/playit/playit.log
+fi
+
 manager="$(detect_init_manager)"
 mkdir -p /opt/playit/share/init
 printf '%s\n' "$manager" > "$PLAYIT_MANAGER_FILE"


### PR DESCRIPTION
## Summary
- Ensure an existing `/var/log/playit/playit.log` file is assigned to the `PLAYIT_USER:PLAYIT_GROUP` ownership during package postinstall.
- Set the log file mode to `0640` so it remains readable to the service user and group while avoiding broader access.
- Leave directory ownership and permissions unchanged for `/etc/playit` and `/var/log/playit`.

## Testing
- Not run (not requested).
- Reviewed the shell patch to confirm the new log-file permission handling is conditional and non-destructive when the file is absent.