### PR TITLE
Add Arch PKGBUILD for binary playit package

### DIFF
--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -1,0 +1,91 @@
+# Maintainer: Patrick Lorio <patrick@playit.gg>
+
+pkgname=playit-bin
+pkgver=1.0.8
+pkgrel=1
+pkgdesc='Making it easy to play games with friends. Makes your server public'
+arch=('x86_64' 'aarch64' 'armv7h' 'i686')
+url='https://playit.gg'
+license=('BSD-2-Clause')
+depends=('logrotate')
+provides=('playit')
+conflicts=('playit')
+install="${pkgname}.install"
+
+_repo='playit-cloud/playit-agent'
+_release_base="https://github.com/${_repo}/releases/download/v${pkgver}"
+_raw_base="https://raw.githubusercontent.com/${_repo}/v${pkgver}"
+
+source=(
+  "playit::${_raw_base}/linux/playit"
+  "logrotate.conf::${_raw_base}/linux/logrotate.conf"
+  "playit.service::${_raw_base}/linux/playit.service"
+  "playit.openrc::${_raw_base}/linux/playit.openrc"
+  "LICENSE.txt::${_raw_base}/LICENSE.txt"
+)
+source_x86_64=(
+  "playit-cli-linux-amd64::${_release_base}/playit-cli-linux-amd64"
+  "playit-linux-amd64::${_release_base}/playit-linux-amd64"
+)
+source_aarch64=(
+  "playit-cli-linux-aarch64::${_release_base}/playit-cli-linux-aarch64"
+  "playit-linux-aarch64::${_release_base}/playit-linux-aarch64"
+)
+source_armv7h=(
+  "playit-cli-linux-armv7::${_release_base}/playit-cli-linux-armv7"
+  "playit-linux-armv7::${_release_base}/playit-linux-armv7"
+)
+source_i686=(
+  "playit-cli-linux-i686::${_release_base}/playit-cli-linux-i686"
+  "playit-linux-i686::${_release_base}/playit-linux-i686"
+)
+
+sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+sha256sums_x86_64=('SKIP' 'SKIP')
+sha256sums_aarch64=('SKIP' 'SKIP')
+sha256sums_armv7h=('SKIP' 'SKIP')
+sha256sums_i686=('SKIP' 'SKIP')
+
+package() {
+  local cli_bin
+  local daemon_bin
+
+  case "${CARCH}" in
+    x86_64)
+      cli_bin='playit-cli-linux-amd64'
+      daemon_bin='playit-linux-amd64'
+      ;;
+    aarch64)
+      cli_bin='playit-cli-linux-aarch64'
+      daemon_bin='playit-linux-aarch64'
+      ;;
+    armv7h)
+      cli_bin='playit-cli-linux-armv7'
+      daemon_bin='playit-linux-armv7'
+      ;;
+    i686)
+      cli_bin='playit-cli-linux-i686'
+      daemon_bin='playit-linux-i686'
+      ;;
+    *)
+      printf 'Unsupported architecture: %s\n' "${CARCH}" >&2
+      return 1
+      ;;
+  esac
+
+  install -Dm0755 "${srcdir}/${cli_bin}" "${pkgdir}/opt/playit/agent"
+  install -Dm0755 "${srcdir}/${daemon_bin}" "${pkgdir}/opt/playit/playitd"
+  install -Dm0755 "${srcdir}/playit" "${pkgdir}/opt/playit/playit"
+
+  install -Dm0644 "${srcdir}/logrotate.conf" "${pkgdir}/etc/logrotate.d/playit"
+  install -Dm0644 "${srcdir}/playit.service" "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  install -Dm0755 "${srcdir}/playit.openrc" "${pkgdir}/opt/playit/share/init/openrc/playit"
+  install -Dm0644 "${srcdir}/LICENSE.txt" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
+
+  install -dm0750 "${pkgdir}/etc/playit"
+  install -dm0750 "${pkgdir}/var/log/playit"
+  install -dm0755 "${pkgdir}/usr/local/bin"
+
+  ln -s /opt/playit/playit "${pkgdir}/usr/local/bin/playit"
+  ln -s /opt/playit/playitd "${pkgdir}/usr/local/bin/playitd"
+}

--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -40,11 +40,19 @@ source_i686=(
   "playit-linux-i686::${_release_base}/playit-linux-i686"
 )
 
-sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
-sha256sums_x86_64=('SKIP' 'SKIP')
-sha256sums_aarch64=('SKIP' 'SKIP')
-sha256sums_armv7h=('SKIP' 'SKIP')
-sha256sums_i686=('SKIP' 'SKIP')
+sha256sums=('daa9b021f23bddaa04c29532088ab3f1967591bba11ed98eb8ced4d53e67858d'
+            '22fc22988fd86ecf62cba09847442cfd628a7a6d7e6dcdffd3833f1f3cb8a9d8'
+            '8029085b8db14175a1a7a7f4f626bc224be969d6c68283de38a4942575ee2842'
+            'fd6b309c4e1008b81675a2ad0ea27e709f02f405a502816c238a73c60b497da9'
+            'f9d32c6b4a6055b2bfa48543d68119efc46ea4606f0d9cc973cb273dcd59be9c')
+sha256sums_x86_64=('ac812035d416f0d10628023ac1c2dfccc1cf4610a72fde42516ca34ad7ae9755'
+                   '544cc9b93384c81d0bbccc7ced5f855594412bd7cc72011d414b73f265fb7ce6')
+sha256sums_aarch64=('647924241fbafaa5616cf8630153f181759fe3cd95cca2821eabe659f90e5d3e'
+                    '8a1c51e72d00caec1688def8c20c1c67c714b99dff05a4147f3639d3fad61594')
+sha256sums_armv7h=('4426464a96e2708f96b0414b74b63132e0edbd682989c87f203b58451c6c4d73'
+                   '99a512d42280103133f13b6e5fb236ee07242f2d6d11da38e3a8cafd13593245')
+sha256sums_i686=('7f8e16c51bd10157b6df6676c21dd5a43054a53583af3f94a7976fe012c72d8a'
+                 'a984232367d411a9a592b9d04a81eb0a0df27994a6464f49b9393e7276b93cbd')
 
 package() {
   local cli_bin

--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -8,7 +8,7 @@ arch=('x86_64' 'aarch64' 'armv7h' 'i686')
 url='https://playit.gg'
 license=('BSD-2-Clause')
 depends=('logrotate')
-provides=('playit')
+provides=("playit=${pkgver}")
 conflicts=('playit')
 install="${pkgname}.install"
 
@@ -84,8 +84,8 @@ package() {
 
   install -dm0750 "${pkgdir}/etc/playit"
   install -dm0750 "${pkgdir}/var/log/playit"
-  install -dm0755 "${pkgdir}/usr/local/bin"
+  install -dm0755 "${pkgdir}/usr/bin"
 
-  ln -s /opt/playit/playit "${pkgdir}/usr/local/bin/playit"
-  ln -s /opt/playit/playitd "${pkgdir}/usr/local/bin/playitd"
+  ln -s /opt/playit/playit "${pkgdir}/usr/bin/playit"
+  ln -s /opt/playit/playitd "${pkgdir}/usr/bin/playitd"
 }

--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Making it easy to play games with friends. Makes your server public'
 arch=('x86_64' 'aarch64' 'armv7h' 'i686')
 url='https://playit.gg'
 license=('BSD-2-Clause')
-depends=('logrotate')
+depends=('logrotate' 'systemd')
 provides=("playit=${pkgver}")
 conflicts=('playit')
 install="${pkgname}.install"
@@ -20,7 +20,7 @@ source=(
   "playit::${_raw_base}/linux/playit"
   "logrotate.conf::${_raw_base}/linux/logrotate.conf"
   "playit.service::${_raw_base}/linux/playit.service"
-  "playit.openrc::${_raw_base}/linux/playit.openrc"
+  "playit.sysusers::${_raw_base}/linux/playit.sysusers"
   "LICENSE.txt::${_raw_base}/LICENSE.txt"
 )
 source_x86_64=(
@@ -40,19 +40,11 @@ source_i686=(
   "playit-linux-i686::${_release_base}/playit-linux-i686"
 )
 
-sha256sums=('daa9b021f23bddaa04c29532088ab3f1967591bba11ed98eb8ced4d53e67858d'
-            '22fc22988fd86ecf62cba09847442cfd628a7a6d7e6dcdffd3833f1f3cb8a9d8'
-            '8029085b8db14175a1a7a7f4f626bc224be969d6c68283de38a4942575ee2842'
-            'fd6b309c4e1008b81675a2ad0ea27e709f02f405a502816c238a73c60b497da9'
-            'f9d32c6b4a6055b2bfa48543d68119efc46ea4606f0d9cc973cb273dcd59be9c')
-sha256sums_x86_64=('ac812035d416f0d10628023ac1c2dfccc1cf4610a72fde42516ca34ad7ae9755'
-                   '544cc9b93384c81d0bbccc7ced5f855594412bd7cc72011d414b73f265fb7ce6')
-sha256sums_aarch64=('647924241fbafaa5616cf8630153f181759fe3cd95cca2821eabe659f90e5d3e'
-                    '8a1c51e72d00caec1688def8c20c1c67c714b99dff05a4147f3639d3fad61594')
-sha256sums_armv7h=('4426464a96e2708f96b0414b74b63132e0edbd682989c87f203b58451c6c4d73'
-                   '99a512d42280103133f13b6e5fb236ee07242f2d6d11da38e3a8cafd13593245')
-sha256sums_i686=('7f8e16c51bd10157b6df6676c21dd5a43054a53583af3f94a7976fe012c72d8a'
-                 'a984232367d411a9a592b9d04a81eb0a0df27994a6464f49b9393e7276b93cbd')
+sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+sha256sums_x86_64=('SKIP' 'SKIP')
+sha256sums_aarch64=('SKIP' 'SKIP')
+sha256sums_armv7h=('SKIP' 'SKIP')
+sha256sums_i686=('SKIP' 'SKIP')
 
 package() {
   local cli_bin
@@ -86,12 +78,11 @@ package() {
   install -Dm0755 "${srcdir}/playit" "${pkgdir}/opt/playit/playit"
 
   install -Dm0644 "${srcdir}/logrotate.conf" "${pkgdir}/etc/logrotate.d/playit"
-  install -Dm0644 "${srcdir}/playit.service" "${pkgdir}/opt/playit/share/init/systemd/playit.service"
-  install -Dm0755 "${srcdir}/playit.openrc" "${pkgdir}/opt/playit/share/init/openrc/playit"
+  install -Dm0644 "${srcdir}/playit.service" "${pkgdir}/usr/lib/systemd/system/playit.service"
+  install -Dm0644 "${srcdir}/playit.sysusers" "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   install -Dm0644 "${srcdir}/LICENSE.txt" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
 
   install -dm0750 "${pkgdir}/etc/playit"
-  install -dm0750 "${pkgdir}/var/log/playit"
   install -dm0755 "${pkgdir}/usr/bin"
 
   ln -s /opt/playit/playit "${pkgdir}/usr/bin/playit"

--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -13,7 +13,7 @@ conflicts=('playit')
 install="${pkgname}.install"
 
 _repo='playit-cloud/playit-agent'
-_release_base="https://github.com/${_repo}/releases/download/v${pkgver}"
+_release_base="https://builds.playit.gg/${pkgver}"
 _raw_base="https://raw.githubusercontent.com/${_repo}/v${pkgver}"
 
 source=(

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -1,124 +1,11 @@
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
-PLAYIT_HOME=/var/lib/playit
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
-SYSTEMD_TEMPLATE=/opt/playit/share/init/systemd/playit.service
-OPENRC_TEMPLATE=/opt/playit/share/init/openrc/playit
-OPENRC_SERVICE=/etc/init.d/playit
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
+SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
-}
-
-nologin_shell() {
-  if [ -x /usr/sbin/nologin ]; then
-    printf '%s\n' /usr/sbin/nologin
-  elif [ -x /sbin/nologin ]; then
-    printf '%s\n' /sbin/nologin
-  else
-    printf '%s\n' /bin/false
-  fi
-}
-
-group_exists() {
-  if have_command getent; then
-    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
-  else
-    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
-  fi
-}
-
-user_exists() {
-  if have_command id; then
-    id -u "$PLAYIT_USER" >/dev/null 2>&1
-  else
-    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
-  fi
-}
-
-ensure_group() {
-  if group_exists; then
-    return 0
-  fi
-
-  if have_command groupadd; then
-    groupadd --system "$PLAYIT_GROUP"
-  elif have_command addgroup; then
-    addgroup -S "$PLAYIT_GROUP"
-  else
-    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
-    exit 1
-  fi
-}
-
-ensure_user() {
-  if user_exists; then
-    return 0
-  fi
-
-  if have_command useradd; then
-    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$(nologin_shell)" "$PLAYIT_USER"
-  elif have_command adduser; then
-    adduser -S -D -H -h "$PLAYIT_HOME" -s "$(nologin_shell)" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
-  else
-    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
-    exit 1
-  fi
-}
-
-systemd_is_active() {
-  have_command systemctl && [ -d /run/systemd/system ]
-}
-
-systemd_is_installed() {
-  have_command systemctl
-}
-
-openrc_is_active() {
-  have_command rc-service &&
-    have_command rc-update &&
-    [ -x /sbin/openrc-run ] &&
-    { [ -e /run/openrc/softlevel ] || [ -d /run/openrc ]; }
-}
-
-openrc_is_installed() {
-  have_command rc-service &&
-    have_command rc-update &&
-    [ -x /sbin/openrc-run ]
-}
-
-detect_init_manager() {
-  systemd_active=0
-  openrc_active=0
-  systemd_installed=0
-  openrc_installed=0
-
-  systemd_is_active && systemd_active=1
-  openrc_is_active && openrc_active=1
-  systemd_is_installed && systemd_installed=1
-  openrc_is_installed && openrc_installed=1
-
-  if [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 0 ]; then
-    echo systemd
-  elif [ "$openrc_active" -eq 1 ] && [ "$systemd_active" -eq 0 ]; then
-    echo openrc
-  elif [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 1 ]; then
-    echo systemd
-  elif [ "$systemd_installed" -eq 1 ] && [ "$openrc_installed" -eq 0 ]; then
-    echo systemd
-  elif [ "$openrc_installed" -eq 1 ] && [ "$systemd_installed" -eq 0 ]; then
-    echo openrc
-  else
-    echo none
-  fi
-}
-
-systemd_unit_path() {
-  if [ -d /lib/systemd/system ] || [ -L /lib/systemd/system ]; then
-    echo /lib/systemd/system/playit.service
-  else
-    echo /usr/lib/systemd/system/playit.service
-  fi
 }
 
 handle_legacy_systemd_unit() {
@@ -134,80 +21,66 @@ handle_legacy_systemd_unit() {
   fi
 }
 
+remove_legacy_unit_path() {
+  legacy_unit="$1"
+
+  if [ ! -e "$legacy_unit" ] && [ ! -L "$legacy_unit" ]; then
+    return 0
+  fi
+
+  if [ "$(readlink -f "$legacy_unit" 2>/dev/null || printf '%s\n' "$legacy_unit")" = "$(readlink -f "$SYSTEMD_UNIT" 2>/dev/null || printf '%s\n' "$SYSTEMD_UNIT")" ]; then
+    return 0
+  fi
+
+  rm -f "$legacy_unit"
+}
+
+provision_user() {
+  if ! have_command systemd-sysusers; then
+    echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
+    exit 1
+  fi
+
+  systemd-sysusers "$SYSUSERS_CONFIG"
+}
+
 prepare_filesystem() {
-  mkdir -p /usr/bin /etc/playit /var/log/playit
+  mkdir -p /usr/bin /etc/playit /opt/playit/share/init
   ln -sfn /opt/playit/playit /usr/bin/playit
   ln -sfn /opt/playit/playitd /usr/bin/playitd
 
   chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
-  chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
-  chmod 0750 /etc/playit /var/log/playit
+  chmod 0750 /etc/playit
 
   if [ -f /var/log/playit/playit.log ]; then
     chmod 0640 /var/log/playit/playit.log
+  fi
+
+  printf '%s\n' systemd > "$PLAYIT_MANAGER_FILE"
+  chmod 0644 "$PLAYIT_MANAGER_FILE"
+
+  if [ -f /etc/playit/playit.toml ]; then
+    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
+    chmod 0600 /etc/playit/playit.toml
   fi
 }
 
 configure_service() {
   mode="$1"
 
-  ensure_group
-  ensure_user
+  provision_user
   prepare_filesystem
+  handle_legacy_systemd_unit
+  remove_legacy_unit_path /lib/systemd/system/playit.service
 
-  manager="$(detect_init_manager)"
-  mkdir -p /opt/playit/share/init
-  printf '%s\n' "$manager" > "$PLAYIT_MANAGER_FILE"
-  chmod 0644 "$PLAYIT_MANAGER_FILE"
+  systemctl daemon-reload || true
+  systemctl enable playit || true
 
-  if [ "$manager" != "none" ] && [ -f /etc/playit/playit.toml ]; then
-    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
-    chmod 0600 /etc/playit/playit.toml
+  if [ "$mode" = install ]; then
+    systemctl start playit || true
+  elif systemctl is-active --quiet playit; then
+    systemctl restart playit || true
   fi
-
-  case "$manager" in
-    systemd)
-      handle_legacy_systemd_unit
-      unit="$(systemd_unit_path)"
-      mkdir -p "$(dirname "$unit")"
-      install -m 0644 "$SYSTEMD_TEMPLATE" "$unit"
-      rm -f "$OPENRC_SERVICE"
-
-      systemctl daemon-reload || true
-      systemctl enable playit || true
-
-      if [ "$mode" = install ]; then
-        systemctl start playit || true
-      elif systemctl is-active --quiet playit; then
-        systemctl restart playit || true
-      fi
-      ;;
-    openrc)
-      mkdir -p "$(dirname "$OPENRC_SERVICE")"
-      install -m 0755 "$OPENRC_TEMPLATE" "$OPENRC_SERVICE"
-      rm -f /lib/systemd/system/playit.service
-      rm -f /usr/lib/systemd/system/playit.service
-
-      rc-update add playit default || true
-
-      if [ "$mode" = install ]; then
-        rc-service playit start || true
-      elif rc-service playit status >/dev/null 2>&1; then
-        rc-service playit restart || true
-      fi
-      ;;
-    *)
-      rm -f /lib/systemd/system/playit.service
-      rm -f /usr/lib/systemd/system/playit.service
-      rm -f "$OPENRC_SERVICE"
-      echo "No supported init manager detected; installed playit binaries without a service file."
-      ;;
-  esac
-}
-
-pre_install() {
-  ensure_group
-  ensure_user
 }
 
 post_install() {
@@ -224,17 +97,7 @@ pre_remove() {
     systemctl disable playit || true
   fi
 
-  if have_command rc-service; then
-    rc-service playit stop || true
-  fi
-
-  if have_command rc-update; then
-    rc-update del playit default || true
-  fi
-
-  rm -f /lib/systemd/system/playit.service
-  rm -f /usr/lib/systemd/system/playit.service
-  rm -f /etc/init.d/playit
+  remove_legacy_unit_path /lib/systemd/system/playit.service
   rm -f /opt/playit/share/init/selected-manager
 
   if [ -L /usr/bin/playit ]; then
@@ -243,6 +106,14 @@ pre_remove() {
 
   if [ -L /usr/bin/playitd ]; then
     rm -f /usr/bin/playitd
+  fi
+
+  if [ -L /usr/local/bin/playit ]; then
+    rm -f /usr/local/bin/playit
+  fi
+
+  if [ -L /usr/local/bin/playitd ]; then
+    rm -f /usr/local/bin/playitd
   fi
 }
 

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -8,6 +8,15 @@ have_command() {
   command -v "$1" >/dev/null 2>&1
 }
 
+remove_symlink_to_target() {
+  path="$1"
+  target="$2"
+
+  if [ -L "$path" ] && [ "$(readlink "$path")" = "$target" ]; then
+    rm -f "$path"
+  fi
+}
+
 handle_legacy_systemd_unit() {
   LEGACY_UNIT=/etc/systemd/system/playit.service
   if [ -f "$LEGACY_UNIT" ] || [ -L "$LEGACY_UNIT" ]; then
@@ -100,21 +109,10 @@ pre_remove() {
   remove_legacy_unit_path /lib/systemd/system/playit.service
   rm -f /opt/playit/share/init/selected-manager
 
-  if [ -L /usr/bin/playit ]; then
-    rm -f /usr/bin/playit
-  fi
-
-  if [ -L /usr/bin/playitd ]; then
-    rm -f /usr/bin/playitd
-  fi
-
-  if [ -L /usr/local/bin/playit ]; then
-    rm -f /usr/local/bin/playit
-  fi
-
-  if [ -L /usr/local/bin/playitd ]; then
-    rm -f /usr/local/bin/playitd
-  fi
+  remove_symlink_to_target /usr/bin/playit /opt/playit/playit
+  remove_symlink_to_target /usr/bin/playitd /opt/playit/playitd
+  remove_symlink_to_target /usr/local/bin/playit /opt/playit/playit
+  remove_symlink_to_target /usr/local/bin/playitd /opt/playit/playitd
 }
 
 post_remove() {

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -135,9 +135,9 @@ handle_legacy_systemd_unit() {
 }
 
 prepare_filesystem() {
-  mkdir -p /usr/local/bin /etc/playit /var/log/playit
-  ln -sfn /opt/playit/playit /usr/local/bin/playit
-  ln -sfn /opt/playit/playitd /usr/local/bin/playitd
+  mkdir -p /usr/bin /etc/playit /var/log/playit
+  ln -sfn /opt/playit/playit /usr/bin/playit
+  ln -sfn /opt/playit/playitd /usr/bin/playitd
 
   chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
   chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
@@ -237,12 +237,12 @@ pre_remove() {
   rm -f /etc/init.d/playit
   rm -f /opt/playit/share/init/selected-manager
 
-  if [ -L /usr/local/bin/playit ]; then
-    rm -f /usr/local/bin/playit
+  if [ -L /usr/bin/playit ]; then
+    rm -f /usr/bin/playit
   fi
 
-  if [ -L /usr/local/bin/playitd ]; then
-    rm -f /usr/local/bin/playitd
+  if [ -L /usr/bin/playitd ]; then
+    rm -f /usr/bin/playitd
   fi
 }
 

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -1,0 +1,253 @@
+PLAYIT_USER=playit
+PLAYIT_GROUP=playit
+PLAYIT_HOME=/var/lib/playit
+PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
+SYSTEMD_TEMPLATE=/opt/playit/share/init/systemd/playit.service
+OPENRC_TEMPLATE=/opt/playit/share/init/openrc/playit
+OPENRC_SERVICE=/etc/init.d/playit
+
+have_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
+
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$(nologin_shell)" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$(nologin_shell)" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
+}
+
+systemd_is_active() {
+  have_command systemctl && [ -d /run/systemd/system ]
+}
+
+systemd_is_installed() {
+  have_command systemctl
+}
+
+openrc_is_active() {
+  have_command rc-service &&
+    have_command rc-update &&
+    [ -x /sbin/openrc-run ] &&
+    { [ -e /run/openrc/softlevel ] || [ -d /run/openrc ]; }
+}
+
+openrc_is_installed() {
+  have_command rc-service &&
+    have_command rc-update &&
+    [ -x /sbin/openrc-run ]
+}
+
+detect_init_manager() {
+  systemd_active=0
+  openrc_active=0
+  systemd_installed=0
+  openrc_installed=0
+
+  systemd_is_active && systemd_active=1
+  openrc_is_active && openrc_active=1
+  systemd_is_installed && systemd_installed=1
+  openrc_is_installed && openrc_installed=1
+
+  if [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 0 ]; then
+    echo systemd
+  elif [ "$openrc_active" -eq 1 ] && [ "$systemd_active" -eq 0 ]; then
+    echo openrc
+  elif [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 1 ]; then
+    echo systemd
+  elif [ "$systemd_installed" -eq 1 ] && [ "$openrc_installed" -eq 0 ]; then
+    echo systemd
+  elif [ "$openrc_installed" -eq 1 ] && [ "$systemd_installed" -eq 0 ]; then
+    echo openrc
+  else
+    echo none
+  fi
+}
+
+systemd_unit_path() {
+  if [ -d /lib/systemd/system ] || [ -L /lib/systemd/system ]; then
+    echo /lib/systemd/system/playit.service
+  else
+    echo /usr/lib/systemd/system/playit.service
+  fi
+}
+
+handle_legacy_systemd_unit() {
+  LEGACY_UNIT=/etc/systemd/system/playit.service
+  if [ -f "$LEGACY_UNIT" ] || [ -L "$LEGACY_UNIT" ]; then
+    BACKUP_UNIT="${LEGACY_UNIT}.pacsave.$(date -u +%Y%m%d%H%M%S)"
+    echo "Moving legacy systemd unit ${LEGACY_UNIT} to ${BACKUP_UNIT} because it shadows the packaged unit"
+    mv "$LEGACY_UNIT" "$BACKUP_UNIT"
+  elif [ -e "$LEGACY_UNIT" ]; then
+    echo "Cannot install playit: ${LEGACY_UNIT} exists but is not a file or symlink" >&2
+    echo "Remove or rename it manually, then reinstall playit." >&2
+    exit 1
+  fi
+}
+
+prepare_filesystem() {
+  mkdir -p /usr/local/bin /etc/playit /var/log/playit
+  ln -sfn /opt/playit/playit /usr/local/bin/playit
+  ln -sfn /opt/playit/playitd /usr/local/bin/playitd
+
+  chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
+  chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
+  chmod 0750 /etc/playit /var/log/playit
+
+  if [ -f /var/log/playit/playit.log ]; then
+    chmod 0640 /var/log/playit/playit.log
+  fi
+}
+
+configure_service() {
+  mode="$1"
+
+  ensure_group
+  ensure_user
+  prepare_filesystem
+
+  manager="$(detect_init_manager)"
+  mkdir -p /opt/playit/share/init
+  printf '%s\n' "$manager" > "$PLAYIT_MANAGER_FILE"
+  chmod 0644 "$PLAYIT_MANAGER_FILE"
+
+  if [ "$manager" != "none" ] && [ -f /etc/playit/playit.toml ]; then
+    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
+    chmod 0600 /etc/playit/playit.toml
+  fi
+
+  case "$manager" in
+    systemd)
+      handle_legacy_systemd_unit
+      unit="$(systemd_unit_path)"
+      mkdir -p "$(dirname "$unit")"
+      install -m 0644 "$SYSTEMD_TEMPLATE" "$unit"
+      rm -f "$OPENRC_SERVICE"
+
+      systemctl daemon-reload || true
+      systemctl enable playit || true
+
+      if [ "$mode" = install ]; then
+        systemctl start playit || true
+      elif systemctl is-active --quiet playit; then
+        systemctl restart playit || true
+      fi
+      ;;
+    openrc)
+      mkdir -p "$(dirname "$OPENRC_SERVICE")"
+      install -m 0755 "$OPENRC_TEMPLATE" "$OPENRC_SERVICE"
+      rm -f /lib/systemd/system/playit.service
+      rm -f /usr/lib/systemd/system/playit.service
+
+      rc-update add playit default || true
+
+      if [ "$mode" = install ]; then
+        rc-service playit start || true
+      elif rc-service playit status >/dev/null 2>&1; then
+        rc-service playit restart || true
+      fi
+      ;;
+    *)
+      rm -f /lib/systemd/system/playit.service
+      rm -f /usr/lib/systemd/system/playit.service
+      rm -f "$OPENRC_SERVICE"
+      echo "No supported init manager detected; installed playit binaries without a service file."
+      ;;
+  esac
+}
+
+pre_install() {
+  ensure_group
+  ensure_user
+}
+
+post_install() {
+  configure_service install
+}
+
+post_upgrade() {
+  configure_service upgrade
+}
+
+pre_remove() {
+  if have_command systemctl; then
+    systemctl stop playit || true
+    systemctl disable playit || true
+  fi
+
+  if have_command rc-service; then
+    rc-service playit stop || true
+  fi
+
+  if have_command rc-update; then
+    rc-update del playit default || true
+  fi
+
+  rm -f /lib/systemd/system/playit.service
+  rm -f /usr/lib/systemd/system/playit.service
+  rm -f /etc/init.d/playit
+  rm -f /opt/playit/share/init/selected-manager
+
+  if [ -L /usr/local/bin/playit ]; then
+    rm -f /usr/local/bin/playit
+  fi
+
+  if [ -L /usr/local/bin/playitd ]; then
+    rm -f /usr/local/bin/playitd
+  fi
+}
+
+post_remove() {
+  if have_command systemctl; then
+    systemctl daemon-reload || true
+  fi
+}

--- a/arch/build/PKGBUILD
+++ b/arch/build/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Making it easy to play games with friends. Makes your server public'
 arch=('x86_64' 'aarch64' 'armv7h' 'i686')
 url='https://playit.gg'
 license=('BSD-2-Clause')
-depends=('logrotate')
+depends=('logrotate' 'systemd')
 makedepends=('cargo' 'git')
 conflicts=('playit-bin')
 install="${pkgname}.install"
@@ -38,12 +38,11 @@ package() {
   install -Dm0755 linux/playit "${pkgdir}/opt/playit/playit"
 
   install -Dm0644 linux/logrotate.conf "${pkgdir}/etc/logrotate.d/playit"
-  install -Dm0644 linux/playit.service "${pkgdir}/opt/playit/share/init/systemd/playit.service"
-  install -Dm0755 linux/playit.openrc "${pkgdir}/opt/playit/share/init/openrc/playit"
+  install -Dm0644 linux/playit.service "${pkgdir}/usr/lib/systemd/system/playit.service"
+  install -Dm0644 linux/playit.sysusers "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   install -Dm0644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
 
   install -dm0750 "${pkgdir}/etc/playit"
-  install -dm0750 "${pkgdir}/var/log/playit"
   install -dm0755 "${pkgdir}/usr/bin"
 
   ln -s /opt/playit/playit "${pkgdir}/usr/bin/playit"

--- a/arch/build/PKGBUILD
+++ b/arch/build/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Patrick Lorio <patrick@playit.gg>
+
+pkgname=playit
+pkgver=1.0.8
+pkgrel=1
+pkgdesc='Making it easy to play games with friends. Makes your server public'
+arch=('x86_64' 'aarch64' 'armv7h' 'i686')
+url='https://playit.gg'
+license=('BSD-2-Clause')
+depends=('logrotate')
+makedepends=('cargo' 'git')
+conflicts=('playit-bin')
+install="${pkgname}.install"
+
+_repo='playit-cloud/playit-agent'
+source=("${pkgname}-${pkgver}::git+https://github.com/${_repo}.git#tag=v${pkgver}")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  cargo fetch --locked --target "${CARCH}-unknown-linux-gnu"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release --package playit-cli --bin playit-cli
+  cargo build --frozen --release --package playitd --bin playitd
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+
+  install -Dm0755 target/release/playit-cli "${pkgdir}/opt/playit/agent"
+  install -Dm0755 target/release/playitd "${pkgdir}/opt/playit/playitd"
+  install -Dm0755 linux/playit "${pkgdir}/opt/playit/playit"
+
+  install -Dm0644 linux/logrotate.conf "${pkgdir}/etc/logrotate.d/playit"
+  install -Dm0644 linux/playit.service "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  install -Dm0755 linux/playit.openrc "${pkgdir}/opt/playit/share/init/openrc/playit"
+  install -Dm0644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
+
+  install -dm0750 "${pkgdir}/etc/playit"
+  install -dm0750 "${pkgdir}/var/log/playit"
+  install -dm0755 "${pkgdir}/usr/bin"
+
+  ln -s /opt/playit/playit "${pkgdir}/usr/bin/playit"
+  ln -s /opt/playit/playitd "${pkgdir}/usr/bin/playitd"
+}

--- a/arch/build/playit.install
+++ b/arch/build/playit.install
@@ -1,124 +1,11 @@
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
-PLAYIT_HOME=/var/lib/playit
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
-SYSTEMD_TEMPLATE=/opt/playit/share/init/systemd/playit.service
-OPENRC_TEMPLATE=/opt/playit/share/init/openrc/playit
-OPENRC_SERVICE=/etc/init.d/playit
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
+SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
-}
-
-nologin_shell() {
-  if [ -x /usr/sbin/nologin ]; then
-    printf '%s\n' /usr/sbin/nologin
-  elif [ -x /sbin/nologin ]; then
-    printf '%s\n' /sbin/nologin
-  else
-    printf '%s\n' /bin/false
-  fi
-}
-
-group_exists() {
-  if have_command getent; then
-    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
-  else
-    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
-  fi
-}
-
-user_exists() {
-  if have_command id; then
-    id -u "$PLAYIT_USER" >/dev/null 2>&1
-  else
-    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
-  fi
-}
-
-ensure_group() {
-  if group_exists; then
-    return 0
-  fi
-
-  if have_command groupadd; then
-    groupadd --system "$PLAYIT_GROUP"
-  elif have_command addgroup; then
-    addgroup -S "$PLAYIT_GROUP"
-  else
-    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
-    exit 1
-  fi
-}
-
-ensure_user() {
-  if user_exists; then
-    return 0
-  fi
-
-  if have_command useradd; then
-    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$(nologin_shell)" "$PLAYIT_USER"
-  elif have_command adduser; then
-    adduser -S -D -H -h "$PLAYIT_HOME" -s "$(nologin_shell)" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
-  else
-    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
-    exit 1
-  fi
-}
-
-systemd_is_active() {
-  have_command systemctl && [ -d /run/systemd/system ]
-}
-
-systemd_is_installed() {
-  have_command systemctl
-}
-
-openrc_is_active() {
-  have_command rc-service &&
-    have_command rc-update &&
-    [ -x /sbin/openrc-run ] &&
-    { [ -e /run/openrc/softlevel ] || [ -d /run/openrc ]; }
-}
-
-openrc_is_installed() {
-  have_command rc-service &&
-    have_command rc-update &&
-    [ -x /sbin/openrc-run ]
-}
-
-detect_init_manager() {
-  systemd_active=0
-  openrc_active=0
-  systemd_installed=0
-  openrc_installed=0
-
-  systemd_is_active && systemd_active=1
-  openrc_is_active && openrc_active=1
-  systemd_is_installed && systemd_installed=1
-  openrc_is_installed && openrc_installed=1
-
-  if [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 0 ]; then
-    echo systemd
-  elif [ "$openrc_active" -eq 1 ] && [ "$systemd_active" -eq 0 ]; then
-    echo openrc
-  elif [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 1 ]; then
-    echo systemd
-  elif [ "$systemd_installed" -eq 1 ] && [ "$openrc_installed" -eq 0 ]; then
-    echo systemd
-  elif [ "$openrc_installed" -eq 1 ] && [ "$systemd_installed" -eq 0 ]; then
-    echo openrc
-  else
-    echo none
-  fi
-}
-
-systemd_unit_path() {
-  if [ -d /lib/systemd/system ] || [ -L /lib/systemd/system ]; then
-    echo /lib/systemd/system/playit.service
-  else
-    echo /usr/lib/systemd/system/playit.service
-  fi
 }
 
 handle_legacy_systemd_unit() {
@@ -134,80 +21,66 @@ handle_legacy_systemd_unit() {
   fi
 }
 
+remove_legacy_unit_path() {
+  legacy_unit="$1"
+
+  if [ ! -e "$legacy_unit" ] && [ ! -L "$legacy_unit" ]; then
+    return 0
+  fi
+
+  if [ "$(readlink -f "$legacy_unit" 2>/dev/null || printf '%s\n' "$legacy_unit")" = "$(readlink -f "$SYSTEMD_UNIT" 2>/dev/null || printf '%s\n' "$SYSTEMD_UNIT")" ]; then
+    return 0
+  fi
+
+  rm -f "$legacy_unit"
+}
+
+provision_user() {
+  if ! have_command systemd-sysusers; then
+    echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
+    exit 1
+  fi
+
+  systemd-sysusers "$SYSUSERS_CONFIG"
+}
+
 prepare_filesystem() {
-  mkdir -p /usr/bin /etc/playit /var/log/playit
+  mkdir -p /usr/bin /etc/playit /opt/playit/share/init
   ln -sfn /opt/playit/playit /usr/bin/playit
   ln -sfn /opt/playit/playitd /usr/bin/playitd
 
   chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
-  chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
-  chmod 0750 /etc/playit /var/log/playit
+  chmod 0750 /etc/playit
 
   if [ -f /var/log/playit/playit.log ]; then
     chmod 0640 /var/log/playit/playit.log
+  fi
+
+  printf '%s\n' systemd > "$PLAYIT_MANAGER_FILE"
+  chmod 0644 "$PLAYIT_MANAGER_FILE"
+
+  if [ -f /etc/playit/playit.toml ]; then
+    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
+    chmod 0600 /etc/playit/playit.toml
   fi
 }
 
 configure_service() {
   mode="$1"
 
-  ensure_group
-  ensure_user
+  provision_user
   prepare_filesystem
+  handle_legacy_systemd_unit
+  remove_legacy_unit_path /lib/systemd/system/playit.service
 
-  manager="$(detect_init_manager)"
-  mkdir -p /opt/playit/share/init
-  printf '%s\n' "$manager" > "$PLAYIT_MANAGER_FILE"
-  chmod 0644 "$PLAYIT_MANAGER_FILE"
+  systemctl daemon-reload || true
+  systemctl enable playit || true
 
-  if [ "$manager" != "none" ] && [ -f /etc/playit/playit.toml ]; then
-    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
-    chmod 0600 /etc/playit/playit.toml
+  if [ "$mode" = install ]; then
+    systemctl start playit || true
+  elif systemctl is-active --quiet playit; then
+    systemctl restart playit || true
   fi
-
-  case "$manager" in
-    systemd)
-      handle_legacy_systemd_unit
-      unit="$(systemd_unit_path)"
-      mkdir -p "$(dirname "$unit")"
-      install -m 0644 "$SYSTEMD_TEMPLATE" "$unit"
-      rm -f "$OPENRC_SERVICE"
-
-      systemctl daemon-reload || true
-      systemctl enable playit || true
-
-      if [ "$mode" = install ]; then
-        systemctl start playit || true
-      elif systemctl is-active --quiet playit; then
-        systemctl restart playit || true
-      fi
-      ;;
-    openrc)
-      mkdir -p "$(dirname "$OPENRC_SERVICE")"
-      install -m 0755 "$OPENRC_TEMPLATE" "$OPENRC_SERVICE"
-      rm -f /lib/systemd/system/playit.service
-      rm -f /usr/lib/systemd/system/playit.service
-
-      rc-update add playit default || true
-
-      if [ "$mode" = install ]; then
-        rc-service playit start || true
-      elif rc-service playit status >/dev/null 2>&1; then
-        rc-service playit restart || true
-      fi
-      ;;
-    *)
-      rm -f /lib/systemd/system/playit.service
-      rm -f /usr/lib/systemd/system/playit.service
-      rm -f "$OPENRC_SERVICE"
-      echo "No supported init manager detected; installed playit binaries without a service file."
-      ;;
-  esac
-}
-
-pre_install() {
-  ensure_group
-  ensure_user
 }
 
 post_install() {
@@ -224,17 +97,7 @@ pre_remove() {
     systemctl disable playit || true
   fi
 
-  if have_command rc-service; then
-    rc-service playit stop || true
-  fi
-
-  if have_command rc-update; then
-    rc-update del playit default || true
-  fi
-
-  rm -f /lib/systemd/system/playit.service
-  rm -f /usr/lib/systemd/system/playit.service
-  rm -f /etc/init.d/playit
+  remove_legacy_unit_path /lib/systemd/system/playit.service
   rm -f /opt/playit/share/init/selected-manager
 
   if [ -L /usr/bin/playit ]; then
@@ -243,6 +106,14 @@ pre_remove() {
 
   if [ -L /usr/bin/playitd ]; then
     rm -f /usr/bin/playitd
+  fi
+
+  if [ -L /usr/local/bin/playit ]; then
+    rm -f /usr/local/bin/playit
+  fi
+
+  if [ -L /usr/local/bin/playitd ]; then
+    rm -f /usr/local/bin/playitd
   fi
 }
 

--- a/arch/build/playit.install
+++ b/arch/build/playit.install
@@ -8,6 +8,15 @@ have_command() {
   command -v "$1" >/dev/null 2>&1
 }
 
+remove_symlink_to_target() {
+  path="$1"
+  target="$2"
+
+  if [ -L "$path" ] && [ "$(readlink "$path")" = "$target" ]; then
+    rm -f "$path"
+  fi
+}
+
 handle_legacy_systemd_unit() {
   LEGACY_UNIT=/etc/systemd/system/playit.service
   if [ -f "$LEGACY_UNIT" ] || [ -L "$LEGACY_UNIT" ]; then
@@ -100,21 +109,10 @@ pre_remove() {
   remove_legacy_unit_path /lib/systemd/system/playit.service
   rm -f /opt/playit/share/init/selected-manager
 
-  if [ -L /usr/bin/playit ]; then
-    rm -f /usr/bin/playit
-  fi
-
-  if [ -L /usr/bin/playitd ]; then
-    rm -f /usr/bin/playitd
-  fi
-
-  if [ -L /usr/local/bin/playit ]; then
-    rm -f /usr/local/bin/playit
-  fi
-
-  if [ -L /usr/local/bin/playitd ]; then
-    rm -f /usr/local/bin/playitd
-  fi
+  remove_symlink_to_target /usr/bin/playit /opt/playit/playit
+  remove_symlink_to_target /usr/bin/playitd /opt/playit/playitd
+  remove_symlink_to_target /usr/local/bin/playit /opt/playit/playit
+  remove_symlink_to_target /usr/local/bin/playitd /opt/playit/playitd
 }
 
 post_remove() {

--- a/arch/build/playit.install
+++ b/arch/build/playit.install
@@ -1,0 +1,253 @@
+PLAYIT_USER=playit
+PLAYIT_GROUP=playit
+PLAYIT_HOME=/var/lib/playit
+PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
+SYSTEMD_TEMPLATE=/opt/playit/share/init/systemd/playit.service
+OPENRC_TEMPLATE=/opt/playit/share/init/openrc/playit
+OPENRC_SERVICE=/etc/init.d/playit
+
+have_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
+
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$(nologin_shell)" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$(nologin_shell)" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
+}
+
+systemd_is_active() {
+  have_command systemctl && [ -d /run/systemd/system ]
+}
+
+systemd_is_installed() {
+  have_command systemctl
+}
+
+openrc_is_active() {
+  have_command rc-service &&
+    have_command rc-update &&
+    [ -x /sbin/openrc-run ] &&
+    { [ -e /run/openrc/softlevel ] || [ -d /run/openrc ]; }
+}
+
+openrc_is_installed() {
+  have_command rc-service &&
+    have_command rc-update &&
+    [ -x /sbin/openrc-run ]
+}
+
+detect_init_manager() {
+  systemd_active=0
+  openrc_active=0
+  systemd_installed=0
+  openrc_installed=0
+
+  systemd_is_active && systemd_active=1
+  openrc_is_active && openrc_active=1
+  systemd_is_installed && systemd_installed=1
+  openrc_is_installed && openrc_installed=1
+
+  if [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 0 ]; then
+    echo systemd
+  elif [ "$openrc_active" -eq 1 ] && [ "$systemd_active" -eq 0 ]; then
+    echo openrc
+  elif [ "$systemd_active" -eq 1 ] && [ "$openrc_active" -eq 1 ]; then
+    echo systemd
+  elif [ "$systemd_installed" -eq 1 ] && [ "$openrc_installed" -eq 0 ]; then
+    echo systemd
+  elif [ "$openrc_installed" -eq 1 ] && [ "$systemd_installed" -eq 0 ]; then
+    echo openrc
+  else
+    echo none
+  fi
+}
+
+systemd_unit_path() {
+  if [ -d /lib/systemd/system ] || [ -L /lib/systemd/system ]; then
+    echo /lib/systemd/system/playit.service
+  else
+    echo /usr/lib/systemd/system/playit.service
+  fi
+}
+
+handle_legacy_systemd_unit() {
+  LEGACY_UNIT=/etc/systemd/system/playit.service
+  if [ -f "$LEGACY_UNIT" ] || [ -L "$LEGACY_UNIT" ]; then
+    BACKUP_UNIT="${LEGACY_UNIT}.pacsave.$(date -u +%Y%m%d%H%M%S)"
+    echo "Moving legacy systemd unit ${LEGACY_UNIT} to ${BACKUP_UNIT} because it shadows the packaged unit"
+    mv "$LEGACY_UNIT" "$BACKUP_UNIT"
+  elif [ -e "$LEGACY_UNIT" ]; then
+    echo "Cannot install playit: ${LEGACY_UNIT} exists but is not a file or symlink" >&2
+    echo "Remove or rename it manually, then reinstall playit." >&2
+    exit 1
+  fi
+}
+
+prepare_filesystem() {
+  mkdir -p /usr/bin /etc/playit /var/log/playit
+  ln -sfn /opt/playit/playit /usr/bin/playit
+  ln -sfn /opt/playit/playitd /usr/bin/playitd
+
+  chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
+  chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
+  chmod 0750 /etc/playit /var/log/playit
+
+  if [ -f /var/log/playit/playit.log ]; then
+    chmod 0640 /var/log/playit/playit.log
+  fi
+}
+
+configure_service() {
+  mode="$1"
+
+  ensure_group
+  ensure_user
+  prepare_filesystem
+
+  manager="$(detect_init_manager)"
+  mkdir -p /opt/playit/share/init
+  printf '%s\n' "$manager" > "$PLAYIT_MANAGER_FILE"
+  chmod 0644 "$PLAYIT_MANAGER_FILE"
+
+  if [ "$manager" != "none" ] && [ -f /etc/playit/playit.toml ]; then
+    chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit/playit.toml
+    chmod 0600 /etc/playit/playit.toml
+  fi
+
+  case "$manager" in
+    systemd)
+      handle_legacy_systemd_unit
+      unit="$(systemd_unit_path)"
+      mkdir -p "$(dirname "$unit")"
+      install -m 0644 "$SYSTEMD_TEMPLATE" "$unit"
+      rm -f "$OPENRC_SERVICE"
+
+      systemctl daemon-reload || true
+      systemctl enable playit || true
+
+      if [ "$mode" = install ]; then
+        systemctl start playit || true
+      elif systemctl is-active --quiet playit; then
+        systemctl restart playit || true
+      fi
+      ;;
+    openrc)
+      mkdir -p "$(dirname "$OPENRC_SERVICE")"
+      install -m 0755 "$OPENRC_TEMPLATE" "$OPENRC_SERVICE"
+      rm -f /lib/systemd/system/playit.service
+      rm -f /usr/lib/systemd/system/playit.service
+
+      rc-update add playit default || true
+
+      if [ "$mode" = install ]; then
+        rc-service playit start || true
+      elif rc-service playit status >/dev/null 2>&1; then
+        rc-service playit restart || true
+      fi
+      ;;
+    *)
+      rm -f /lib/systemd/system/playit.service
+      rm -f /usr/lib/systemd/system/playit.service
+      rm -f "$OPENRC_SERVICE"
+      echo "No supported init manager detected; installed playit binaries without a service file."
+      ;;
+  esac
+}
+
+pre_install() {
+  ensure_group
+  ensure_user
+}
+
+post_install() {
+  configure_service install
+}
+
+post_upgrade() {
+  configure_service upgrade
+}
+
+pre_remove() {
+  if have_command systemctl; then
+    systemctl stop playit || true
+    systemctl disable playit || true
+  fi
+
+  if have_command rc-service; then
+    rc-service playit stop || true
+  fi
+
+  if have_command rc-update; then
+    rc-update del playit default || true
+  fi
+
+  rm -f /lib/systemd/system/playit.service
+  rm -f /usr/lib/systemd/system/playit.service
+  rm -f /etc/init.d/playit
+  rm -f /opt/playit/share/init/selected-manager
+
+  if [ -L /usr/bin/playit ]; then
+    rm -f /usr/bin/playit
+  fi
+
+  if [ -L /usr/bin/playitd ]; then
+    rm -f /usr/bin/playitd
+  fi
+}
+
+post_remove() {
+  if have_command systemctl; then
+    systemctl daemon-reload || true
+  fi
+}

--- a/arch/test-pkgbuilds.sh
+++ b/arch/test-pkgbuilds.sh
@@ -126,23 +126,21 @@ assert_package_layout() {
   assert_path "${pkgdir}/opt/playit/agent"
   assert_path "${pkgdir}/opt/playit/playitd"
   assert_path "${pkgdir}/opt/playit/playit"
-  assert_path "${pkgdir}/opt/playit/share/init/systemd/playit.service"
-  assert_path "${pkgdir}/opt/playit/share/init/openrc/playit"
   assert_path "${pkgdir}/etc/logrotate.d/playit"
+  assert_path "${pkgdir}/usr/lib/systemd/system/playit.service"
+  assert_path "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   assert_path "${pkgdir}/usr/share/licenses/${license_dir}/LICENSE.txt"
   assert_path "${pkgdir}/etc/playit"
-  assert_path "${pkgdir}/var/log/playit"
   assert_symlink "${pkgdir}/usr/bin/playit" /opt/playit/playit
   assert_symlink "${pkgdir}/usr/bin/playitd" /opt/playit/playitd
 
   assert_mode "${pkgdir}/opt/playit/agent" 755
   assert_mode "${pkgdir}/opt/playit/playitd" 755
   assert_mode "${pkgdir}/opt/playit/playit" 755
-  assert_mode "${pkgdir}/opt/playit/share/init/systemd/playit.service" 644
-  assert_mode "${pkgdir}/opt/playit/share/init/openrc/playit" 755
   assert_mode "${pkgdir}/etc/logrotate.d/playit" 644
+  assert_mode "${pkgdir}/usr/lib/systemd/system/playit.service" 644
+  assert_mode "${pkgdir}/usr/lib/sysusers.d/playit.conf" 644
   assert_mode "${pkgdir}/etc/playit" 750
-  assert_mode "${pkgdir}/var/log/playit" 750
 }
 
 test_bin_pkgbuild() {

--- a/arch/test-pkgbuilds.sh
+++ b/arch/test-pkgbuilds.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${PLAYIT_ARCH_TEST_IMAGE:-docker.io/library/alpine:latest}"
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+REPO_DIR="$(cd -- "$(dirname -- "${SCRIPT_PATH}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 [--inside-container]
+
+Runs Arch PKGBUILD smoke tests in an Alpine container using podman.
+
+Environment:
+  PLAYIT_ARCH_TEST_IMAGE  Container image to use (default: ${IMAGE})
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "${1:-}" != "--inside-container" ]]; then
+  if ! command -v podman >/dev/null 2>&1; then
+    echo "podman is required to run Arch PKGBUILD tests" >&2
+    exit 1
+  fi
+
+  exec podman run --rm \
+    --volume "${REPO_DIR}:/work:Z" \
+    --workdir /work \
+    "${IMAGE}" \
+    /bin/sh -ceu '
+      apk add --no-cache bash build-base ca-certificates cargo coreutils curl file findutils git rust
+      exec bash arch/test-pkgbuilds.sh --inside-container
+    '
+fi
+
+require_file() {
+  if [[ ! -f "$1" ]]; then
+    echo "missing required file: $1" >&2
+    exit 1
+  fi
+}
+
+source_url() {
+  local source_entry="$1"
+
+  if [[ "${source_entry}" == *::* ]]; then
+    printf '%s\n' "${source_entry#*::}"
+  else
+    printf '%s\n' "${source_entry}"
+  fi
+}
+
+source_name() {
+  local source_entry="$1"
+  local source_path
+
+  if [[ "${source_entry}" == *::* ]]; then
+    printf '%s\n' "${source_entry%%::*}"
+    return
+  fi
+
+  source_path="${source_entry%%#*}"
+  printf '%s\n' "${source_path##*/}"
+}
+
+download_sources() {
+  local destination="$1"
+  shift
+
+  mkdir -p "${destination}"
+
+  local source_entry
+  for source_entry in "$@"; do
+    local url name
+    url="$(source_url "${source_entry}")"
+    name="$(source_name "${source_entry}")"
+    echo "Downloading ${name}"
+    curl -fL --retry 3 --retry-delay 2 -o "${destination}/${name}" "${url}"
+  done
+}
+
+assert_path() {
+  if [[ ! -e "$1" && ! -L "$1" ]]; then
+    echo "expected path missing: $1" >&2
+    exit 1
+  fi
+}
+
+assert_symlink() {
+  local path="$1"
+  local target="$2"
+
+  if [[ ! -L "${path}" ]]; then
+    echo "expected symlink missing: ${path}" >&2
+    exit 1
+  fi
+
+  local actual
+  actual="$(readlink "${path}")"
+  if [[ "${actual}" != "${target}" ]]; then
+    echo "unexpected symlink target for ${path}: ${actual} != ${target}" >&2
+    exit 1
+  fi
+}
+
+assert_mode() {
+  local path="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(stat -c '%a' "${path}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "unexpected mode for ${path}: ${actual} != ${expected}" >&2
+    exit 1
+  fi
+}
+
+assert_package_layout() {
+  local pkgdir="$1"
+  local license_dir="$2"
+
+  assert_path "${pkgdir}/opt/playit/agent"
+  assert_path "${pkgdir}/opt/playit/playitd"
+  assert_path "${pkgdir}/opt/playit/playit"
+  assert_path "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  assert_path "${pkgdir}/opt/playit/share/init/openrc/playit"
+  assert_path "${pkgdir}/etc/logrotate.d/playit"
+  assert_path "${pkgdir}/usr/share/licenses/${license_dir}/LICENSE.txt"
+  assert_path "${pkgdir}/etc/playit"
+  assert_path "${pkgdir}/var/log/playit"
+  assert_symlink "${pkgdir}/usr/bin/playit" /opt/playit/playit
+  assert_symlink "${pkgdir}/usr/bin/playitd" /opt/playit/playitd
+
+  assert_mode "${pkgdir}/opt/playit/agent" 755
+  assert_mode "${pkgdir}/opt/playit/playitd" 755
+  assert_mode "${pkgdir}/opt/playit/playit" 755
+  assert_mode "${pkgdir}/opt/playit/share/init/systemd/playit.service" 644
+  assert_mode "${pkgdir}/opt/playit/share/init/openrc/playit" 755
+  assert_mode "${pkgdir}/etc/logrotate.d/playit" 644
+  assert_mode "${pkgdir}/etc/playit" 750
+  assert_mode "${pkgdir}/var/log/playit" 750
+}
+
+test_bin_pkgbuild() {
+  echo "==> Testing arch/bin PKGBUILD"
+
+  local test_dir srcdir pkgdir
+  test_dir="$(mktemp -d)"
+  srcdir="${test_dir}/src"
+  pkgdir="${test_dir}/pkg"
+
+  (
+    set -euo pipefail
+    # shellcheck disable=SC2034
+    CARCH=x86_64
+    # shellcheck disable=SC1091
+    source arch/bin/PKGBUILD
+    download_sources "${srcdir}" "${source[@]}" "${source_x86_64[@]}"
+    package
+    assert_package_layout "${pkgdir}" playit-bin
+    file "${pkgdir}/opt/playit/agent"
+    file "${pkgdir}/opt/playit/playitd"
+  )
+
+  rm -rf "${test_dir}"
+}
+
+test_build_pkgbuild() {
+  echo "==> Testing arch/build PKGBUILD"
+
+  local test_dir srcdir pkgdir source_entry url clone_url clone_dir
+  test_dir="$(mktemp -d)"
+  srcdir="${test_dir}/src"
+  pkgdir="${test_dir}/pkg"
+  mkdir -p "${srcdir}" "${pkgdir}"
+
+  (
+    set -euo pipefail
+    # shellcheck disable=SC2034
+    CARCH=x86_64
+    # shellcheck disable=SC1091
+    source arch/build/PKGBUILD
+
+    source_entry="${source[0]}"
+    url="$(source_url "${source_entry}")"
+    clone_url="${url#git+}"
+    clone_url="${clone_url%%#*}"
+    clone_dir="${srcdir}/$(source_name "${source_entry}")"
+    git clone --depth 1 --branch "v${pkgver}" "${clone_url}" "${clone_dir}"
+
+    export CARGO_HOME="${test_dir}/cargo-home"
+    export CARGO_TARGET_DIR="${clone_dir}/target"
+
+    prepare
+    build
+    package
+    assert_package_layout "${pkgdir}" playit
+    file "${pkgdir}/opt/playit/agent"
+    file "${pkgdir}/opt/playit/playitd"
+  )
+
+  rm -rf "${test_dir}"
+}
+
+require_file arch/bin/PKGBUILD
+require_file arch/bin/playit-bin.install
+require_file arch/build/PKGBUILD
+require_file arch/build/playit.install
+
+bash -n arch/bin/PKGBUILD
+bash -n arch/bin/playit-bin.install
+bash -n arch/build/PKGBUILD
+bash -n arch/build/playit.install
+
+test_bin_pkgbuild
+test_build_pkgbuild
+
+echo "PKGBUILD tests passed"

--- a/arch/update-bin-pkgbuild-shasum.sh
+++ b/arch/update-bin-pkgbuild-shasum.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${PLAYIT_ARCH_TEST_IMAGE:-docker.io/library/alpine:latest}"
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+REPO_DIR="$(cd -- "$(dirname -- "${SCRIPT_PATH}")/.." && pwd)"
+PKGBUILD_PATH="arch/bin/PKGBUILD"
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 [--inside-container]
+
+Updates sha256sums in ${PKGBUILD_PATH} by running makepkg --geninteg
+inside an Alpine container.
+
+Environment:
+  PLAYIT_ARCH_TEST_IMAGE  Container image to use (default: ${IMAGE})
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "${1:-}" != "--inside-container" ]]; then
+  if ! command -v podman >/dev/null 2>&1; then
+    echo "podman is required to update PKGBUILD checksums" >&2
+    exit 1
+  fi
+
+  exec podman run --rm \
+    --volume "${REPO_DIR}:/work:Z" \
+    --workdir /work \
+    "${IMAGE}" \
+    /bin/sh -ceu '
+      apk add --no-cache bash ca-certificates curl fakeroot git pacman sudo
+      exec bash arch/update-bin-pkgbuild-shasum.sh --inside-container
+    '
+fi
+
+require_file() {
+  if [[ ! -f "$1" ]]; then
+    echo "missing required file: $1" >&2
+    exit 1
+  fi
+}
+
+extract_sha256sums() {
+  awk '
+    /^sha256sums(_x86_64|_aarch64|_armv7h|_i686)?=\(/ {
+      print
+      if ($0 !~ /\)/) {
+        in_block = 1
+      }
+      next
+    }
+    in_block {
+      print
+      if ($0 ~ /\)/) {
+        in_block = 0
+      }
+    }
+  ' "$1"
+}
+
+replace_sha256sums() {
+  local pkgbuild="$1"
+  local sums_file="$2"
+  local tmp
+
+  tmp="$(mktemp)"
+  awk -v sums_file="${sums_file}" '
+    BEGIN {
+      while ((getline line < sums_file) > 0) {
+        generated = generated line ORS
+      }
+      close(sums_file)
+    }
+    skip {
+      if ($0 ~ /\)/) {
+        skip = 0
+      }
+      next
+    }
+    /^sha256sums(_x86_64|_aarch64|_armv7h|_i686)?=\(/ {
+      if (!inserted) {
+        printf "%s", generated
+        inserted = 1
+      }
+      if ($0 !~ /\)/) {
+        skip = 1
+      }
+      next
+    }
+    { print }
+  ' "${pkgbuild}" > "${tmp}"
+  mv "${tmp}" "${pkgbuild}"
+}
+
+require_file "${PKGBUILD_PATH}"
+require_file arch/bin/playit-bin.install
+
+bash -n "${PKGBUILD_PATH}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+mkdir -p "${work_dir}/pkg"
+cp "${PKGBUILD_PATH}" arch/bin/playit-bin.install "${work_dir}/pkg/"
+
+adduser -D builder >/dev/null
+chown -R builder:builder "${work_dir}"
+
+(
+  cd "${work_dir}/pkg"
+  sudo -u builder makepkg --geninteg > "${work_dir}/makepkg-geninteg.out"
+)
+
+extract_sha256sums "${work_dir}/makepkg-geninteg.out" > "${work_dir}/sha256sums.out"
+
+if [[ ! -s "${work_dir}/sha256sums.out" ]]; then
+  echo "makepkg did not produce sha256sums output" >&2
+  exit 1
+fi
+
+replace_sha256sums "${PKGBUILD_PATH}" "${work_dir}/sha256sums.out"
+bash -n "${PKGBUILD_PATH}"
+
+echo "Updated ${PKGBUILD_PATH} sha256sums"

--- a/build-scripts/set-release-number.sh
+++ b/build-scripts/set-release-number.sh
@@ -9,6 +9,11 @@ PACKAGES=(
   playitd
 )
 
+ARCH_PKGBUILDS=(
+  arch/build/PKGBUILD
+  arch/bin/PKGBUILD
+)
+
 # root workspace package version
 sed -Ei '/^\[workspace\.package\]/,/^\[/{s/^version = "[^"]+"/version = "'"$VERSION"'"/}' Cargo.toml
 
@@ -16,6 +21,11 @@ sed -Ei '/^\[workspace\.package\]/,/^\[/{s/^version = "[^"]+"/version = "'"$VERS
 for pkg in "${PACKAGES[@]}"; do
   find packages -name Cargo.toml -type f -print0 | xargs -0 sed -Ei \
     's/('"$pkg"' = \{[^}]*version = )"[^"]+"/\1"'"$VERSION"'"/'
+done
+
+# Arch package versions
+for pkgbuild in "${ARCH_PKGBUILDS[@]}"; do
+  sed -Ei 's/^pkgver=.*/pkgver='"$VERSION"'/' "$pkgbuild"
 done
 
 IFS=. read -r MAJOR MINOR PATCH <<<"$VERSION"

--- a/build-scripts/set-release-number.sh
+++ b/build-scripts/set-release-number.sh
@@ -14,6 +14,39 @@ ARCH_PKGBUILDS=(
   arch/bin/PKGBUILD
 )
 
+reset_arch_bin_pkgbuild_shasums() {
+  local pkgbuild="arch/bin/PKGBUILD"
+  local tmp
+
+  tmp="$(mktemp)"
+  awk '
+    BEGIN {
+      replacements["sha256sums"] = "sha256sums=(\047SKIP\047 \047SKIP\047 \047SKIP\047 \047SKIP\047 \047SKIP\047)"
+      replacements["sha256sums_x86_64"] = "sha256sums_x86_64=(\047SKIP\047 \047SKIP\047)"
+      replacements["sha256sums_aarch64"] = "sha256sums_aarch64=(\047SKIP\047 \047SKIP\047)"
+      replacements["sha256sums_armv7h"] = "sha256sums_armv7h=(\047SKIP\047 \047SKIP\047)"
+      replacements["sha256sums_i686"] = "sha256sums_i686=(\047SKIP\047 \047SKIP\047)"
+    }
+    skip {
+      if ($0 ~ /\)/) {
+        skip = 0
+      }
+      next
+    }
+    /^sha256sums(_x86_64|_aarch64|_armv7h|_i686)?=\(/ {
+      name = $0
+      sub(/=.*/, "", name)
+      print replacements[name]
+      if ($0 !~ /\)/) {
+        skip = 1
+      }
+      next
+    }
+    { print }
+  ' "$pkgbuild" > "$tmp"
+  mv "$tmp" "$pkgbuild"
+}
+
 # root workspace package version
 sed -Ei '/^\[workspace\.package\]/,/^\[/{s/^version = "[^"]+"/version = "'"$VERSION"'"/}' Cargo.toml
 
@@ -27,6 +60,7 @@ done
 for pkgbuild in "${ARCH_PKGBUILDS[@]}"; do
   sed -Ei 's/^pkgver=.*/pkgver='"$VERSION"'/' "$pkgbuild"
 done
+reset_arch_bin_pkgbuild_shasums
 
 IFS=. read -r MAJOR MINOR PATCH <<<"$VERSION"
 


### PR DESCRIPTION
## Summary
- Add a new `playit-bin` Arch PKGBUILD for prebuilt binaries across `x86_64`, `aarch64`, `armv7h`, and `i686`.
- Package the daemon, CLI, service templates, logrotate config, and license into Arch-friendly paths.
- Add install script logic to create the `playit` user/group, wire up systemd or OpenRC, and clean up on remove.

## Testing
- Not run
- Reviewed PKGBUILD source layout and install script behavior for package install, upgrade, and removal flows
- Verified architecture-specific source selection paths are defined for all supported targets