### PR TITLE
Add sysusers.d file to create playit user

### DIFF
--- a/linux/sysusers.conf
+++ b/linux/sysusers.conf
@@ -1,0 +1,2 @@
+# the exclamation mark means login is forbidden
+u! playit - "playit.gg daemon user"


### PR DESCRIPTION
This is the preferred way to create new users on systemd systems. Without it (or `useradd`), the corresponding user directive fails:

https://github.com/playit-cloud/playit-agent/blob/5831b025df20221239117d1ad3bfb462533615a4/linux/playit.service#L8-L9