### PR TITLE
Improve tunnel startup logs and daemon diagnostics

### DIFF
--- a/packages/agent_core/src/agent_control/address_selector.rs
+++ b/packages/agent_core/src/agent_control/address_selector.rs
@@ -25,7 +25,7 @@ impl<IO: PacketIO> AddressSelector<IO> {
         let mut buffer: Vec<u8> = Vec::new();
 
         for addr in self.options {
-            tracing::info!(?addr, "trying to establish tunnel connection");
+            tracing::debug!(?addr, "trying to establish tunnel connection");
 
             let is_ip6 = addr.is_ipv6();
             let attempts = if is_ip6 { 1 } else { 3 };
@@ -78,7 +78,7 @@ impl<IO: PacketIO> AddressSelector<IO> {
 
                                     match msg.content {
                                         ControlResponse::Pong(pong) => {
-                                            tracing::info!(
+                                            tracing::debug!(
                                                 ?pong,
                                                 "got initial pong from tunnel server"
                                             );
@@ -108,7 +108,7 @@ impl<IO: PacketIO> AddressSelector<IO> {
                             tracing::error!(?error, "failed to receive UDP packet");
                         }
                         Err(_) => {
-                            tracing::warn!(%addr, "waited {}ms for pong", (i + 1) * 500);
+                            tracing::debug!(%addr, "waited {}ms for pong", (i + 1) * 500);
                         }
                     }
                 }

--- a/packages/agent_core/src/agent_control/connected_control.rs
+++ b/packages/agent_core/src/agent_control/connected_control.rs
@@ -157,7 +157,7 @@ impl<IO: PacketIO> ConnectedControl<IO> {
                         }
                     }
                     ControlResponse::RequestQueued => {
-                        tracing::info!("register queued, waiting 1s");
+                        tracing::debug!("register queued, waiting 1s");
                         tokio::time::sleep(Duration::from_secs(1)).await;
                         break;
                     }

--- a/packages/agent_core/src/agent_control/established_control.rs
+++ b/packages/agent_core/src/agent_control/established_control.rs
@@ -174,7 +174,7 @@ impl<A: AuthResource, IO: PacketIO> EstablishedControl<A, IO> {
         self.registered = registered;
         self.pong_at_auth = self.conn.pong_latest.clone();
 
-        tracing::info!(
+        tracing::debug!(
             last_pong = ?self.pong_at_auth,
             "authenticate control"
         );
@@ -192,7 +192,7 @@ impl<A: AuthResource, IO: PacketIO> EstablishedControl<A, IO> {
         if let ControlFeed::Response(res) = &feed {
             match &res.content {
                 ControlResponse::AgentRegistered(registered) => {
-                    tracing::info!(details = ?registered, "agent registered");
+                    tracing::debug!(details = ?registered, "agent registered");
                     self.registered = registered.clone();
                 }
                 ControlResponse::Pong(pong) => {

--- a/packages/agent_core/src/agent_control/maintained_control.rs
+++ b/packages/agent_core/src/agent_control/maintained_control.rs
@@ -97,7 +97,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
             .try_timeout(Duration::from_secs(10))
             .await?;
 
-        tracing::info!(old = %self.control.conn.pong_latest.tunnel_addr, new = %connected.pong_latest.tunnel_addr, "update control address");
+        tracing::debug!(old = %self.control.conn.pong_latest.tunnel_addr, new = %connected.pong_latest.tunnel_addr, "update control address");
         connected.reset_established(&mut self.control, registered);
 
         Ok(true)
@@ -123,7 +123,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
 
     pub async fn update(&mut self) -> Option<TunnelControlEvent> {
         if let Some(reason) = self.control.is_expired() {
-            tracing::warn!(?reason, "session expired");
+            tracing::warn!(?reason, "control session expired; reconnecting");
 
             if let Err(error) = self
                 .control
@@ -164,7 +164,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
         if interval < now - self.last_keep_alive {
             self.last_keep_alive = now;
 
-            tracing::info!(time_till_expire, "send KeepAlive");
+            tracing::debug!(time_till_expire, "send KeepAlive");
             if let Err(error) = self
                 .control
                 .send_keep_alive(100)
@@ -192,14 +192,14 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
                         return Some(TunnelControlEvent::UdpChannelDetails(details));
                     }
                     ControlResponse::Unauthorized => {
-                        tracing::info!("session no longer authorized");
+                        tracing::debug!("session no longer authorized");
                         self.control.set_expired();
                     }
                     ControlResponse::Pong(pong) => {
                         self.last_pong = now_milli();
 
                         if pong.client_addr != self.control.pong_at_auth.client_addr {
-                            tracing::info!(
+                            tracing::debug!(
                                 new_client = %pong.client_addr,
                                 old_client = %self.control.pong_at_auth.client_addr,
                                 "client ip changed"
@@ -225,7 +225,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
         }
 
         if self.last_pong != 0 && now_milli() - self.last_pong > 6_000 {
-            tracing::info!("timeout waiting for pong");
+            tracing::debug!("timeout waiting for pong");
 
             self.last_pong = 0;
             self.control.set_expired();

--- a/packages/agent_core/src/agent_control/maintained_control.rs
+++ b/packages/agent_core/src/agent_control/maintained_control.rs
@@ -97,7 +97,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
             .try_timeout(Duration::from_secs(10))
             .await?;
 
-        tracing::debug!(old = %self.control.conn.pong_latest.tunnel_addr, new = %connected.pong_latest.tunnel_addr, "update control address");
+        tracing::info!(old = %self.control.conn.pong_latest.tunnel_addr, new = %connected.pong_latest.tunnel_addr, "update control address");
         connected.reset_established(&mut self.control, registered);
 
         Ok(true)
@@ -225,7 +225,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
         }
 
         if self.last_pong != 0 && now_milli() - self.last_pong > 6_000 {
-            tracing::debug!("timeout waiting for pong");
+            tracing::warn!("timeout waiting for pong");
 
             self.last_pong = 0;
             self.control.set_expired();

--- a/packages/agent_core/src/network/lan_address.rs
+++ b/packages/agent_core/src/network/lan_address.rs
@@ -20,16 +20,16 @@ impl LanAddress {
 
             match socket.bind(SocketAddrV4::new(local_ip, 0).into()) {
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to bind connection to special local address to support IP based banning: {:?}",
+                    tracing::debug!(
+                        "could not bind special loopback address; continuing without per-client loopback IP support: {:?}",
                         e
                     );
                 }
                 Ok(_) => {
                     match socket.connect(host).await {
                         Err(e) => {
-                            tracing::warn!(
-                                "Failed to establish connection using special lan {} for flow {:?} {:?}",
+                            tracing::debug!(
+                                "could not connect using special loopback address {}; continuing with normal local address for flow {:?}: {:?}",
                                 local_ip,
                                 (peer, host),
                                 e
@@ -41,7 +41,7 @@ impl LanAddress {
             }
         }
 
-        tracing::warn!(is_loopback, host_ip = %host.ip(), special_lan_ip, "not using special lan address");
+        tracing::debug!(is_loopback, host_ip = %host.ip(), special_lan_ip, "not using special lan address");
         match TcpStream::connect(host).await {
             Err(e) => {
                 tracing::error!(
@@ -79,8 +79,8 @@ impl LanAddress {
                 Err(bad_port_error) => {
                     match UdpSocket::bind(SocketAddrV4::new(local_ip, 0)).await {
                         Ok(v) => {
-                            tracing::warn!(
-                                "Failed to bind UDP port to {} to have connections survive agent restart: {:?}",
+                            tracing::debug!(
+                                "could not bind preferred UDP source port {}; continuing with a random local port: {:?}",
                                 local_port,
                                 bad_port_error
                             );
@@ -88,8 +88,8 @@ impl LanAddress {
                         }
                         Err(bad_local_ip_err) => {
                             let v = UdpSocket::bind(SocketAddrV4::new(0.into(), 0)).await?;
-                            tracing::warn!(
-                                "Failed to bind UDP to special local address, in-game ip banning will not work: {:?}",
+                            tracing::debug!(
+                                "could not bind special loopback address for UDP; continuing without per-client loopback IP support: {:?}",
                                 bad_local_ip_err
                             );
                             Ok(v)
@@ -117,7 +117,10 @@ impl LanAddress {
                 Ok(v) => Ok(v),
                 Err(bad_port_error) => {
                     let v = UdpSocket::bind(fallback_addr).await?;
-                    tracing::warn!("Failed to bind UDP to special port: {:?}", bad_port_error);
+                    tracing::debug!(
+                        "could not bind preferred UDP source port; continuing with a random local port: {:?}",
+                        bad_port_error
+                    );
                     Ok(v)
                 }
             }

--- a/packages/agent_core/src/network/origin_lookup.rs
+++ b/packages/agent_core/src/network/origin_lookup.rs
@@ -123,7 +123,7 @@ impl OriginIp {
                             ?error,
                             %hostname,
                             port,
-                            "failed to resolve origin hostname"
+                            "failed to resolve configured local hostname for tunnel; check the tunnel local address or local DNS configuration"
                         );
                         return None;
                     }

--- a/packages/agent_core/src/network/tcp/tcp_clients.rs
+++ b/packages/agent_core/src/network/tcp/tcp_clients.rs
@@ -191,7 +191,7 @@ impl Worker {
                     let client_id = self.next_client_id;
                     self.next_client_id = client_id + 1;
 
-                    tracing::debug!(?details, id = client_id, "New TCP Client");
+                    tracing::info!(?details, id = client_id, "New TCP Client");
 
                     let Some(found) = self.lookup.lookup(details.tunnel_id, true).await else {
                         tracing::debug!(

--- a/packages/agent_core/src/network/tcp/tcp_clients.rs
+++ b/packages/agent_core/src/network/tcp/tcp_clients.rs
@@ -171,7 +171,7 @@ impl Worker {
             let event = tokio::select! {
                 recv_opt = self.events.recv() => {
                     let Some(event) = recv_opt else {
-                        tracing::info!("TcpClients worker closed because event channel closed");
+                        tracing::debug!("TcpClients worker closed because event channel closed");
                         break;
                     };
                     event
@@ -181,7 +181,7 @@ impl Worker {
                     Event::ClearOld
                 },
                 _ = self.cancel.cancelled() => {
-                    tracing::info!("TcpClients worker closed via cancel");
+                    tracing::debug!("TcpClients worker closed via cancel");
                     break
                 },
             };
@@ -191,10 +191,10 @@ impl Worker {
                     let client_id = self.next_client_id;
                     self.next_client_id = client_id + 1;
 
-                    tracing::info!(?details, id = client_id, "New TCP Client");
+                    tracing::debug!(?details, id = client_id, "New TCP Client");
 
                     let Some(found) = self.lookup.lookup(details.tunnel_id, true).await else {
-                        tracing::info!(
+                        tracing::debug!(
                             tunnel_id = details.tunnel_id,
                             "Could not find tunnel for new client"
                         );
@@ -341,14 +341,23 @@ impl Worker {
                             Ok(Err(error)) => {
                                 tracing::error!(
                                     ?error,
-                                    "io error failed to connect to origin: {:?}",
-                                    origin_addr
+                                    %origin_addr,
+                                    tunnel_id = details.tunnel_id,
+                                    port_offset = details.port_offset,
+                                    source_addr = %details.peer_addr,
+                                    "failed to connect to local TCP server; check that your server is running and listening on the configured local address"
                                 );
                                 tcp_errors().new_client_origin_connect_error.inc();
                                 return;
                             }
                             Err(_) => {
-                                tracing::error!("timeout connecting to origin: {}", origin_addr);
+                                tracing::error!(
+                                    %origin_addr,
+                                    tunnel_id = details.tunnel_id,
+                                    port_offset = details.port_offset,
+                                    source_addr = %details.peer_addr,
+                                    "timed out connecting to local TCP server; check firewall rules and that the server is listening on the configured local address"
+                                );
                                 tcp_errors().new_client_origin_connect_timeout.inc();
                                 return;
                             }
@@ -430,17 +439,17 @@ impl Worker {
                         let since_orig = now.max(last_use.origin_to_tunn) - last_use.origin_to_tunn;
 
                         if 90_000 < since_tunn && 30_000 < since_orig {
-                            tracing::info!(id = client.id, "clear old: 90s since tunnel data");
+                            tracing::debug!(id = client.id, "clear old: 90s since tunnel data");
                             return false;
                         }
 
                         if 90_000 < since_orig && 30_000 < since_tunn {
-                            tracing::info!(id = client.id, "clear old: 90s since origin data");
+                            tracing::debug!(id = client.id, "clear old: 90s since origin data");
                             return false;
                         }
 
                         if 60_000 < since_tunn && 60_000 < since_orig {
-                            tracing::info!(id = client.id, "clear old: 60s since any data");
+                            tracing::debug!(id = client.id, "clear old: 60s since any data");
                             return false;
                         }
 

--- a/packages/agent_core/src/network/tcp/tcp_pipe.rs
+++ b/packages/agent_core/src/network/tcp/tcp_pipe.rs
@@ -123,7 +123,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> Worker<R, W> {
             // Keep the pipe cooperative when both sockets stay continuously ready.
             tokio::select! {
                 _ = self.cancel.cancelled() => {
-                    tracing::info!("TcpPipe cancelled");
+                    tracing::debug!("TcpPipe cancelled");
                     break;
                 }
                 _ = tokio::task::yield_now() => {}
@@ -134,7 +134,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> Worker<R, W> {
                 .run_until_cancelled(self.from.read(&mut buffer[..]))
                 .await
             else {
-                tracing::info!("TcpPipe cancelled");
+                tracing::debug!("TcpPipe cancelled");
                 break;
             };
 
@@ -147,7 +147,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> Worker<R, W> {
             };
 
             if byte_count == 0 {
-                tracing::info!("pipe ended due to EOF");
+                tracing::debug!("pipe ended due to EOF");
                 break;
             }
 

--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -276,7 +276,13 @@ impl UdpClients {
         let socket = match key.create_socket(special_lan, target_addr).await {
             Ok(socket) => Arc::new(socket),
             Err(error) => {
-                tracing::error!(?error, "failed to create socket");
+                tracing::error!(
+                    ?error,
+                    target_addr = %target_addr,
+                    source_addr = %key.source_addr,
+                    tunnel_id = key.tunnel_id,
+                    "failed to open local UDP socket for tunnel traffic"
+                );
                 return;
             }
         };

--- a/packages/agent_core/src/playit_agent.rs
+++ b/packages/agent_core/src/playit_agent.rs
@@ -123,7 +123,7 @@ impl PlayitAgent {
                         break;
                     };
                     if sent {
-                        tracing::info!("udp channel requires auth, sent auth request");
+                        tracing::debug!("udp channel requires auth, sent auth request");
                     }
                 }
 
@@ -151,7 +151,7 @@ impl PlayitAgent {
                         }
                     }
                     Some(TunnelControlEvent::UdpChannelDetails(udp_details)) => {
-                        tracing::info!("udp session details received");
+                        tracing::debug!("udp session details received");
                         let _ = udp_session_tx.try_send(udp_details);
                     }
                     None => {}
@@ -184,7 +184,7 @@ impl PlayitAgent {
                     }
                     session_opt = udp_session_rx.recv() => {
                         let Some(session) = session_opt else {
-                            tracing::warn!("udp session channel closed");
+                            tracing::debug!("udp session channel closed");
                             break;
                         };
                         udp_channel.update_session(session).await;

--- a/packages/playitd/src/daemon.rs
+++ b/packages/playitd/src/daemon.rs
@@ -79,6 +79,29 @@ enum LoadedSecret {
     Invalid(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunningSummary {
+    tunnel_count: usize,
+    pending_tunnel_count: usize,
+    disabled_tunnel_count: usize,
+    account_status: &'static str,
+}
+
+impl RunningSummary {
+    fn from_state(state: &AgentState) -> Self {
+        Self {
+            tunnel_count: state.tunnels.len(),
+            pending_tunnel_count: state.pending_tunnels.len(),
+            disabled_tunnel_count: state
+                .tunnels
+                .iter()
+                .filter(|tunnel| tunnel.is_disabled)
+                .count(),
+            account_status: service_account_status_label(&state.account_status),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct VersionDetails {
     pub variant_id: String,
@@ -603,7 +626,8 @@ async fn build_agent_with_reprovisioning(
                 }
             }
             Err(error) => {
-                let message = format!("Failed to create agent: {error:?}");
+                let message = setup_error_user_message(&error);
+                tracing::error!(?error, %message, "failed to start playit agent");
                 let service_error = daemon_error(ServiceErrorCode::Internal, message.clone(), true);
                 publish_runtime_state(
                     &runtime.state_cache,
@@ -771,6 +795,7 @@ async fn broadcast_agent_state(
 ) {
     let mut interval = tokio::time::interval(Duration::from_secs(3));
     let mut guest_login_link: Option<(String, u64)> = None;
+    let mut last_running_summary: Option<RunningSummary> = None;
 
     loop {
         tokio::select! {
@@ -838,6 +863,30 @@ async fn broadcast_agent_state(
                             login_link,
                             start_time,
                         };
+
+                        let summary = RunningSummary::from_state(&state);
+                        if last_running_summary.as_ref() != Some(&summary) {
+                            if last_running_summary.is_none() {
+                                tracing::info!(
+                                    agent_id = %state.agent_id,
+                                    tunnel_count = summary.tunnel_count,
+                                    pending_tunnel_count = summary.pending_tunnel_count,
+                                    disabled_tunnel_count = summary.disabled_tunnel_count,
+                                    account_status = summary.account_status,
+                                    "playit connected; tunnels loaded"
+                                );
+                            } else {
+                                tracing::info!(
+                                    agent_id = %state.agent_id,
+                                    tunnel_count = summary.tunnel_count,
+                                    pending_tunnel_count = summary.pending_tunnel_count,
+                                    disabled_tunnel_count = summary.disabled_tunnel_count,
+                                    account_status = summary.account_status,
+                                    "playit tunnel state updated"
+                                );
+                            }
+                            last_running_summary = Some(summary);
+                        }
 
                         let lifecycle = AgentLifecycle::Running(state);
                         state_cache.set_lifecycle(lifecycle.clone()).await;
@@ -1132,9 +1181,59 @@ fn daemon_error(code: ServiceErrorCode, message: String, retryable: bool) -> Ser
     }
 }
 
+fn service_account_status_label(status: &ServiceAccountStatus) -> &'static str {
+    match status {
+        ServiceAccountStatus::Unknown => "unknown",
+        ServiceAccountStatus::Guest => "guest",
+        ServiceAccountStatus::EmailNotVerified => "email_not_verified",
+        ServiceAccountStatus::Verified => "verified",
+    }
+}
+
 fn agent_disabled_over_limit_message() -> String {
     "This account is over the agent limit. Delete an unused agent or upgrade the account, then the service will retry."
         .to_string()
+}
+
+fn setup_error_user_message(error: &SetupError) -> String {
+    match error {
+        SetupError::FailedToConnect => {
+            "Could not connect to playit tunnel servers. Check your internet connection, firewall, VPN, or DNS settings, then restart playit.".to_string()
+        }
+        SetupError::RequestError(_) => {
+            "Could not reach the playit API. Check your internet connection or try again later.".to_string()
+        }
+        SetupError::ApiError(ApiResponseError::Auth(AuthError::InvalidAgentKey | AuthError::NoLongerValid)) => {
+            "The configured playit secret is no longer valid. Run `playit setup` to provision a new secret.".to_string()
+        }
+        SetupError::ApiError(error) => {
+            format!("The playit API rejected the agent startup request: {error}")
+        }
+        SetupError::ApiFail(payload)
+            if matches!(
+                serde_json::from_str::<ProtoRegisterError>(payload),
+                Ok(ProtoRegisterError::AgentDisabledOverLimit)
+            ) =>
+        {
+            agent_disabled_over_limit_message()
+        }
+        SetupError::ApiFail(_) => {
+            "The playit API rejected the agent registration request. Check your account and tunnel configuration, then try again.".to_string()
+        }
+        SetupError::Timeout(_) => {
+            "Timed out while connecting to playit. Check your network/firewall and try again.".to_string()
+        }
+        SetupError::IoError(error) => {
+            format!("Could not open a required network socket: {error}")
+        }
+        SetupError::AttemptingToAuthWithOldFlow
+        | SetupError::FailedToDecodeSignedAgentRegisterHex
+        | SetupError::NoResponseFromAuthenticate
+        | SetupError::RegisterInvalidSignature
+        | SetupError::RegisterUnauthorized => {
+            format!("Failed to start the playit agent: {error}")
+        }
+    }
 }
 
 fn is_invalid_agent_secret_error(error: &SetupError) -> bool {
@@ -1262,9 +1361,14 @@ fn create_log_parent_dir(path: &Path) -> Result<(), String> {
 mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use super::{DaemonOptions, run_daemon};
+    use super::{DaemonOptions, RunningSummary, run_daemon, setup_error_user_message};
+    use playit_agent_core::agent_control::errors::{SetupError, TimeoutSource};
+    use playit_api_client::api::{ApiResponseError, AuthError, ProtoRegisterError};
     use playit_ipc::ipc::IpcClient;
-    use playit_ipc::model::{AgentLifecycle, ServicePhase};
+    use playit_ipc::model::{
+        AccountStatus as ServiceAccountStatus, AgentLifecycle, AgentState, ServicePhase,
+        TunnelState,
+    };
 
     fn unique_test_path(name: &str, extension: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -1276,6 +1380,79 @@ mod tests {
                 .as_nanos(),
             extension,
         ))
+    }
+
+    #[test]
+    fn setup_error_message_handles_connection_failure() {
+        let message = setup_error_user_message(&SetupError::FailedToConnect);
+
+        assert!(message.contains("Could not connect to playit tunnel servers"));
+        assert!(message.contains("firewall"));
+    }
+
+    #[test]
+    fn setup_error_message_handles_timeout() {
+        let message = setup_error_user_message(&SetupError::Timeout(TimeoutSource {
+            file_name: "test.rs",
+            line_no: 1,
+        }));
+
+        assert!(message.contains("Timed out while connecting to playit"));
+    }
+
+    #[test]
+    fn setup_error_message_handles_io_error() {
+        let message = setup_error_user_message(&SetupError::IoError(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            "address already in use",
+        )));
+
+        assert!(message.contains("Could not open a required network socket"));
+        assert!(message.contains("address already in use"));
+    }
+
+    #[test]
+    fn setup_error_message_handles_invalid_secret() {
+        let message = setup_error_user_message(&SetupError::ApiError(ApiResponseError::Auth(
+            AuthError::NoLongerValid,
+        )));
+
+        assert!(message.contains("secret is no longer valid"));
+        assert!(message.contains("playit setup"));
+    }
+
+    #[test]
+    fn setup_error_message_handles_agent_limit() {
+        let payload = serde_json::to_string(&ProtoRegisterError::AgentDisabledOverLimit).unwrap();
+        let message = setup_error_user_message(&SetupError::ApiFail(payload));
+
+        assert!(message.contains("over the agent limit"));
+    }
+
+    #[test]
+    fn running_summary_counts_tunnel_state() {
+        let state = AgentState {
+            account_status: ServiceAccountStatus::Verified,
+            tunnels: vec![
+                TunnelState {
+                    is_disabled: false,
+                    ..TunnelState::default()
+                },
+                TunnelState {
+                    is_disabled: true,
+                    ..TunnelState::default()
+                },
+            ],
+            pending_tunnels: vec![Default::default()],
+            ..AgentState::default()
+        };
+
+        let summary = RunningSummary::from_state(&state);
+
+        assert_eq!(summary.tunnel_count, 2);
+        assert_eq!(summary.pending_tunnel_count, 1);
+        assert_eq!(summary.disabled_tunnel_count, 1);
+        assert_eq!(summary.account_status, "verified");
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Reduce noise by demoting routine tunnel, TCP, UDP, and control-path events from `info`/`warn` to `debug`.
- Improve error messages for local socket setup, origin lookup, and tunnel connection failures with more actionable context.
- Add daemon startup and running-state summaries so startup/reconnect transitions are easier to trace.
- Map setup failures to user-facing guidance for common cases like network issues, invalid secrets, API rejection, and agent limits.

## Testing
- Added unit coverage for setup error message mapping in `packages/playitd/src/daemon.rs`.
- Added unit coverage for running-state summary counts and account-status labeling in `packages/playitd/src/daemon.rs`.
- Not run: full test suite.
- Not run: manual daemon startup verification.