### PR TITLE
Add Arch debug package conflict checks

### DIFF
--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -9,7 +9,7 @@ url='https://playit.gg'
 license=('BSD-2-Clause')
 depends=('logrotate' 'systemd')
 provides=("playit=${pkgver}")
-conflicts=('playit')
+conflicts=('playit' 'playit-debug')
 install="${pkgname}.install"
 
 _repo='playit-cloud/playit-agent'

--- a/arch/build/PKGBUILD
+++ b/arch/build/PKGBUILD
@@ -9,7 +9,7 @@ url='https://playit.gg'
 license=('BSD-2-Clause')
 depends=('logrotate' 'systemd')
 makedepends=('cargo')
-conflicts=('playit-bin')
+conflicts=('playit-bin' 'playit-bin-debug')
 install="${pkgname}.install"
 # ring's native objects can fail to link with Arch package LTO enabled.
 options=('!lto')

--- a/arch/test-pkgbuilds.sh
+++ b/arch/test-pkgbuilds.sh
@@ -119,6 +119,21 @@ assert_mode() {
   fi
 }
 
+assert_array_contains() {
+  local needle="$1"
+  shift
+
+  local value
+  for value in "$@"; do
+    if [[ "${value}" == "${needle}" ]]; then
+      return
+    fi
+  done
+
+  echo "expected array value missing: ${needle}" >&2
+  exit 1
+}
+
 assert_package_layout() {
   local pkgdir="$1"
   local license_dir="$2"
@@ -157,6 +172,7 @@ test_bin_pkgbuild() {
     CARCH=x86_64
     # shellcheck disable=SC1091
     source arch/bin/PKGBUILD
+    assert_array_contains playit-debug "${conflicts[@]}"
     download_sources "${srcdir}" "${source[@]}" "${source_x86_64[@]}"
     package
     assert_package_layout "${pkgdir}" playit-bin
@@ -199,6 +215,7 @@ test_build_pkgbuild() {
     CARCH=x86_64
     # shellcheck disable=SC1091
     source arch/build/PKGBUILD
+    assert_array_contains playit-bin-debug "${conflicts[@]}"
 
     download_sources "${srcdir}" "${source[@]}"
     extract_sources "${srcdir}" "${source[@]}"


### PR DESCRIPTION
## Summary
- Add `playit-debug` and `playit-bin-debug` to the Arch package conflict lists so debug and release packages cannot be installed together.
- Extend the Arch PKGBUILD test script to assert the expected conflict entries for both package variants.

## Testing
- Not run locally.
- Added shell assertions in `arch/test-pkgbuilds.sh` to verify the `conflicts` arrays for `arch/bin/PKGBUILD` and `arch/build/PKGBUILD`.