### PR TITLE
Avoid Alpine package conflicts in nfpm manifests

### DIFF
--- a/build-scripts/nfpm-openrc.yaml
+++ b/build-scripts/nfpm-openrc.yaml
@@ -14,6 +14,7 @@ license: BSD-2-Clause
 depends:
   - logrotate
   - openrc
+  - "!playit"
 conflicts:
   - playit
 contents:

--- a/build-scripts/nfpm.yaml
+++ b/build-scripts/nfpm.yaml
@@ -14,6 +14,12 @@ license: BSD-2-Clause
 depends:
   - logrotate
   - systemd
+overrides:
+  apk:
+    depends:
+      - logrotate
+      - systemd
+      - "!playit-openrc"
 contents:
   - src: ${PLAYIT_CLI_BIN}
     dst: /opt/playit/agent


### PR DESCRIPTION
## Summary
- Add Alpine `apk` dependency overrides to the main nfpm manifest so it does not conflict with `playit-openrc`.
- Mark the OpenRC package dependency on `playit` as negated to avoid co-installation issues on Alpine.
- Keep the existing package conflict declarations while making the dependency graph explicit for Alpine builds.

## Testing
- Not run (manifest-only change).
- Reviewed the nfpm YAML diff for Alpine-specific dependency and conflict adjustments.