### PR TITLE
Fix /var/log/playit ownership in postinstall

### DIFF
--- a/build-scripts/nfpm/postinstall.sh
+++ b/build-scripts/nfpm/postinstall.sh
@@ -60,12 +60,13 @@ fi
 
 systemd-sysusers "$SYSUSERS_CONFIG"
 
-mkdir -p /usr/bin /etc/playit /opt/playit/share/init
+mkdir -p /usr/bin /etc/playit /var/log/playit /opt/playit/share/init
 ln -sfn /opt/playit/playit /usr/bin/playit
 ln -sfn /opt/playit/playitd /usr/bin/playitd
 
 chown "$PLAYIT_USER:$PLAYIT_GROUP" /etc/playit
-chmod 0750 /etc/playit
+chown -R "$PLAYIT_USER:$PLAYIT_GROUP" /var/log/playit
+chmod 0750 /etc/playit /var/log/playit
 
 if [ -f /var/log/playit/playit.log ]; then
   chmod 0640 /var/log/playit/playit.log


### PR DESCRIPTION
## Summary
- Create `/var/log/playit` during package postinstall so the log directory exists on fresh installs.
- Set the log directory ownership to `PLAYIT_USER:PLAYIT_GROUP` recursively before tightening permissions.
- Keep `/etc/playit` and `/var/log/playit` at `0750`, while preserving log file handling for `/var/log/playit/playit.log`.

## Testing
- Not run (packaging script change only).
- Verified the diff updates `build-scripts/nfpm/postinstall.sh` to create and chown `/var/log/playit`.
- Verified existing log file permission logic remains in place for `/var/log/playit/playit.log`.