### PR TITLE
Support non-systemd package installs

### DIFF
--- a/arch/bin/PKGBUILD
+++ b/arch/bin/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='Tool to make your locally running game server public (Binary Version)'
 arch=('x86_64' 'aarch64' 'armv7h' 'i686')
 url='https://playit.gg'
 license=('BSD-2-Clause')
-depends=('logrotate' 'systemd')
+depends=('logrotate')
 provides=("playit=${pkgver}")
 conflicts=('playit' 'playit-debug')
 install="${pkgname}.install"
@@ -22,6 +22,7 @@ source=(
   "playit::${_raw_base}/linux/playit"
   "logrotate.conf::${_raw_base}/linux/logrotate.conf"
   "playit.service::${_raw_base}/linux/playit.service"
+  "playit.openrc::${_raw_base}/linux/playit.openrc"
   "playit.sysusers::${_raw_base}/linux/playit.sysusers"
   "LICENSE.txt::${_raw_base}/LICENSE.txt"
 )
@@ -45,6 +46,7 @@ source_i686=(
 sha256sums=('daa9b021f23bddaa04c29532088ab3f1967591bba11ed98eb8ced4d53e67858d'
             '0e22e81c51c31325dd2acff4ec7399ceede0e83384547457ef64ec52fa72cdd1'
             '066b84e12162c344eb602cc4550447bf7ee05c8b6d2975ea94e356fc9977050d'
+            'fd6b309c4e1008b81675a2ad0ea27e709f02f405a502816c238a73c60b497da9'
             'a07e7ae69701e99224bfcd8a464b028c7e7eef241017900701b70ac903e42d39'
             'f9d32c6b4a6055b2bfa48543d68119efc46ea4606f0d9cc973cb273dcd59be9c')
 sha256sums_x86_64=('4d1e9584c7c771f0f4727fca435376c2c07b1bf84149eba2ac00bd8c3100ba25'
@@ -89,6 +91,8 @@ package() {
 
   install -Dm0644 "${srcdir}/logrotate.conf" "${pkgdir}/etc/logrotate.d/playit"
   install -Dm0644 "${srcdir}/playit.service" "${pkgdir}/usr/lib/systemd/system/playit.service"
+  install -Dm0644 "${srcdir}/playit.service" "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  install -Dm0755 "${srcdir}/playit.openrc" "${pkgdir}/opt/playit/share/init/openrc/playit"
   install -Dm0644 "${srcdir}/playit.sysusers" "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   install -Dm0644 "${srcdir}/LICENSE.txt" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
 

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -1,11 +1,68 @@
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
+PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
-SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
+}
+
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
+
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  shell="$(nologin_shell)"
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$shell" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$shell" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
 }
 
 remove_symlink_to_target() {
@@ -45,12 +102,8 @@ remove_legacy_unit_path() {
 }
 
 provision_user() {
-  if ! have_command systemd-sysusers; then
-    echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
-    exit 1
-  fi
-
-  systemd-sysusers "$SYSUSERS_CONFIG"
+  ensure_group
+  ensure_user
 }
 
 prepare_filesystem() {
@@ -82,13 +135,15 @@ configure_service() {
   handle_legacy_systemd_unit
   remove_legacy_unit_path /lib/systemd/system/playit.service
 
-  systemctl daemon-reload || true
-  systemctl enable playit || true
+  if have_command systemctl; then
+    systemctl daemon-reload || true
+    systemctl enable playit || true
 
-  if [ "$mode" = install ]; then
-    systemctl start playit || true
-  elif systemctl is-active --quiet playit; then
-    systemctl restart playit || true
+    if [ "$mode" = install ]; then
+      systemctl start playit || true
+    elif systemctl is-active --quiet playit; then
+      systemctl restart playit || true
+    fi
   fi
 }
 

--- a/arch/bin/playit-bin.install
+++ b/arch/bin/playit-bin.install
@@ -2,6 +2,7 @@ PLAYIT_USER=playit
 PLAYIT_GROUP=playit
 PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
@@ -102,8 +103,12 @@ remove_legacy_unit_path() {
 }
 
 provision_user() {
-  ensure_group
-  ensure_user
+  if have_command systemd-sysusers; then
+    systemd-sysusers "$SYSUSERS_CONFIG"
+  else
+    ensure_group
+    ensure_user
+  fi
 }
 
 prepare_filesystem() {

--- a/arch/build/PKGBUILD
+++ b/arch/build/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='Tool to make your locally running game server public'
 arch=('x86_64' 'aarch64' 'armv7h' 'i686')
 url='https://playit.gg'
 license=('BSD-2-Clause')
-depends=('logrotate' 'systemd')
+depends=('logrotate')
 makedepends=('cargo')
 conflicts=('playit-bin' 'playit-bin-debug')
 install="${pkgname}.install"
@@ -44,6 +44,8 @@ package() {
 
   install -Dm0644 linux/logrotate.conf "${pkgdir}/etc/logrotate.d/playit"
   install -Dm0644 linux/playit.service "${pkgdir}/usr/lib/systemd/system/playit.service"
+  install -Dm0644 linux/playit.service "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  install -Dm0755 linux/playit.openrc "${pkgdir}/opt/playit/share/init/openrc/playit"
   install -Dm0644 linux/playit.sysusers "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   install -Dm0644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
 

--- a/arch/build/playit.install
+++ b/arch/build/playit.install
@@ -1,11 +1,68 @@
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
+PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
-SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
+}
+
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
+
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  shell="$(nologin_shell)"
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$shell" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$shell" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
 }
 
 remove_symlink_to_target() {
@@ -45,12 +102,8 @@ remove_legacy_unit_path() {
 }
 
 provision_user() {
-  if ! have_command systemd-sysusers; then
-    echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
-    exit 1
-  fi
-
-  systemd-sysusers "$SYSUSERS_CONFIG"
+  ensure_group
+  ensure_user
 }
 
 prepare_filesystem() {
@@ -82,13 +135,15 @@ configure_service() {
   handle_legacy_systemd_unit
   remove_legacy_unit_path /lib/systemd/system/playit.service
 
-  systemctl daemon-reload || true
-  systemctl enable playit || true
+  if have_command systemctl; then
+    systemctl daemon-reload || true
+    systemctl enable playit || true
 
-  if [ "$mode" = install ]; then
-    systemctl start playit || true
-  elif systemctl is-active --quiet playit; then
-    systemctl restart playit || true
+    if [ "$mode" = install ]; then
+      systemctl start playit || true
+    elif systemctl is-active --quiet playit; then
+      systemctl restart playit || true
+    fi
   fi
 }
 

--- a/arch/build/playit.install
+++ b/arch/build/playit.install
@@ -2,6 +2,7 @@ PLAYIT_USER=playit
 PLAYIT_GROUP=playit
 PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
@@ -102,8 +103,12 @@ remove_legacy_unit_path() {
 }
 
 provision_user() {
-  ensure_group
-  ensure_user
+  if have_command systemd-sysusers; then
+    systemd-sysusers "$SYSUSERS_CONFIG"
+  else
+    ensure_group
+    ensure_user
+  fi
 }
 
 prepare_filesystem() {

--- a/arch/test-pkgbuilds.sh
+++ b/arch/test-pkgbuilds.sh
@@ -134,6 +134,19 @@ assert_array_contains() {
   exit 1
 }
 
+assert_array_not_contains() {
+  local needle="$1"
+  shift
+
+  local value
+  for value in "$@"; do
+    if [[ "${value}" == "${needle}" ]]; then
+      echo "unexpected array value present: ${needle}" >&2
+      exit 1
+    fi
+  done
+}
+
 assert_package_layout() {
   local pkgdir="$1"
   local license_dir="$2"
@@ -143,6 +156,8 @@ assert_package_layout() {
   assert_path "${pkgdir}/opt/playit/playit"
   assert_path "${pkgdir}/etc/logrotate.d/playit"
   assert_path "${pkgdir}/usr/lib/systemd/system/playit.service"
+  assert_path "${pkgdir}/opt/playit/share/init/systemd/playit.service"
+  assert_path "${pkgdir}/opt/playit/share/init/openrc/playit"
   assert_path "${pkgdir}/usr/lib/sysusers.d/playit.conf"
   assert_path "${pkgdir}/usr/share/licenses/${license_dir}/LICENSE.txt"
   assert_path "${pkgdir}/etc/playit"
@@ -154,6 +169,8 @@ assert_package_layout() {
   assert_mode "${pkgdir}/opt/playit/playit" 755
   assert_mode "${pkgdir}/etc/logrotate.d/playit" 644
   assert_mode "${pkgdir}/usr/lib/systemd/system/playit.service" 644
+  assert_mode "${pkgdir}/opt/playit/share/init/systemd/playit.service" 644
+  assert_mode "${pkgdir}/opt/playit/share/init/openrc/playit" 755
   assert_mode "${pkgdir}/usr/lib/sysusers.d/playit.conf" 644
   assert_mode "${pkgdir}/etc/playit" 750
 }
@@ -173,6 +190,8 @@ test_bin_pkgbuild() {
     # shellcheck disable=SC1091
     source arch/bin/PKGBUILD
     assert_array_contains playit-debug "${conflicts[@]}"
+    assert_array_contains logrotate "${depends[@]}"
+    assert_array_not_contains systemd "${depends[@]}"
     download_sources "${srcdir}" "${source[@]}" "${source_x86_64[@]}"
     package
     assert_package_layout "${pkgdir}" playit-bin
@@ -216,6 +235,8 @@ test_build_pkgbuild() {
     # shellcheck disable=SC1091
     source arch/build/PKGBUILD
     assert_array_contains playit-bin-debug "${conflicts[@]}"
+    assert_array_contains logrotate "${depends[@]}"
+    assert_array_not_contains systemd "${depends[@]}"
 
     download_sources "${srcdir}" "${source[@]}"
     extract_sources "${srcdir}" "${source[@]}"
@@ -242,6 +263,8 @@ bash -n arch/bin/PKGBUILD
 bash -n arch/bin/playit-bin.install
 bash -n arch/build/PKGBUILD
 bash -n arch/build/playit.install
+sh -n build-scripts/nfpm/preinstall.sh
+sh -n build-scripts/nfpm/postinstall.sh
 
 test_bin_pkgbuild
 test_build_pkgbuild

--- a/build-scripts/nfpm-openrc.yaml
+++ b/build-scripts/nfpm-openrc.yaml
@@ -46,6 +46,14 @@ contents:
     dst: /etc/init.d/playit
     file_info:
       mode: 0755
+  - src: ./linux/playit.service
+    dst: /opt/playit/share/init/systemd/playit.service
+    file_info:
+      mode: 0644
+  - src: ./linux/playit.openrc
+    dst: /opt/playit/share/init/openrc/playit
+    file_info:
+      mode: 0755
   - dst: /etc/playit
     type: dir
     file_info:

--- a/build-scripts/nfpm.yaml
+++ b/build-scripts/nfpm.yaml
@@ -13,12 +13,10 @@ homepage: https://playit.gg
 license: BSD-2-Clause
 depends:
   - logrotate
-  - systemd
 overrides:
   apk:
     depends:
       - logrotate
-      - systemd
       - "!playit-openrc"
 contents:
   - src: ${PLAYIT_CLI_BIN}
@@ -53,6 +51,14 @@ contents:
     dst: /usr/lib/systemd/system/playit.service
     file_info:
       mode: 0644
+  - src: ./linux/playit.service
+    dst: /opt/playit/share/init/systemd/playit.service
+    file_info:
+      mode: 0644
+  - src: ./linux/playit.openrc
+    dst: /opt/playit/share/init/openrc/playit
+    file_info:
+      mode: 0755
   - dst: /etc/playit
     type: dir
     file_info:

--- a/build-scripts/nfpm/postinstall.sh
+++ b/build-scripts/nfpm/postinstall.sh
@@ -5,6 +5,7 @@ PLAYIT_USER=playit
 PLAYIT_GROUP=playit
 PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
@@ -68,6 +69,15 @@ ensure_user() {
   fi
 }
 
+provision_user() {
+  if have_command systemd-sysusers; then
+    systemd-sysusers "$SYSUSERS_CONFIG"
+  else
+    ensure_group
+    ensure_user
+  fi
+}
+
 is_fresh_install() {
   case "${1:-}" in
     ""|0|1|install)
@@ -110,8 +120,7 @@ remove_legacy_unit_path() {
   rm -f "$legacy_unit"
 }
 
-ensure_group
-ensure_user
+provision_user
 
 mkdir -p /usr/bin /etc/playit /opt/playit/share/init
 ln -sfn /opt/playit/playit /usr/bin/playit

--- a/build-scripts/nfpm/postinstall.sh
+++ b/build-scripts/nfpm/postinstall.sh
@@ -3,12 +3,69 @@ set -eu
 
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
+PLAYIT_HOME=/nonexistent
 PLAYIT_MANAGER_FILE=/opt/playit/share/init/selected-manager
-SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
 SYSTEMD_UNIT=/usr/lib/systemd/system/playit.service
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
+}
+
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
+
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  shell="$(nologin_shell)"
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$shell" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$shell" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
 }
 
 is_fresh_install() {
@@ -53,12 +110,8 @@ remove_legacy_unit_path() {
   rm -f "$legacy_unit"
 }
 
-if ! have_command systemd-sysusers; then
-  echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
-  exit 1
-fi
-
-systemd-sysusers "$SYSUSERS_CONFIG"
+ensure_group
+ensure_user
 
 mkdir -p /usr/bin /etc/playit /opt/playit/share/init
 ln -sfn /opt/playit/playit /usr/bin/playit
@@ -82,11 +135,13 @@ fi
 handle_legacy_systemd_unit
 remove_legacy_unit_path /lib/systemd/system/playit.service
 
-systemctl daemon-reload || true
-systemctl enable playit || true
+if have_command systemctl; then
+  systemctl daemon-reload || true
+  systemctl enable playit || true
 
-if is_fresh_install "$@"; then
-  systemctl start playit || true
-elif systemctl is-active --quiet playit; then
-  systemctl restart playit || true
+  if is_fresh_install "$@"; then
+    systemctl start playit || true
+  elif systemctl is-active --quiet playit; then
+    systemctl restart playit || true
+  fi
 fi

--- a/build-scripts/nfpm/preinstall.sh
+++ b/build-scripts/nfpm/preinstall.sh
@@ -2,16 +2,69 @@
 set -eu
 
 PLAYIT_USER=playit
+PLAYIT_GROUP=playit
 PLAYIT_HOME=/nonexistent
-SYSUSERS_SHELL=/usr/sbin/nologin
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
 }
 
-if ! have_command systemd-sysusers; then
-  echo "Cannot provision ${PLAYIT_USER} user with systemd-sysusers: command not found" >&2
-  exit 1
-fi
+nologin_shell() {
+  if [ -x /usr/sbin/nologin ]; then
+    printf '%s\n' /usr/sbin/nologin
+  elif [ -x /sbin/nologin ]; then
+    printf '%s\n' /sbin/nologin
+  else
+    printf '%s\n' /bin/false
+  fi
+}
 
-systemd-sysusers --inline "u ${PLAYIT_USER} - \"playit service user\" ${PLAYIT_HOME} ${SYSUSERS_SHELL}"
+group_exists() {
+  if have_command getent; then
+    getent group "$PLAYIT_GROUP" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_GROUP}:" /etc/group 2>/dev/null
+  fi
+}
+
+user_exists() {
+  if have_command id; then
+    id -u "$PLAYIT_USER" >/dev/null 2>&1
+  else
+    grep -q "^${PLAYIT_USER}:" /etc/passwd 2>/dev/null
+  fi
+}
+
+ensure_group() {
+  if group_exists; then
+    return 0
+  fi
+
+  if have_command groupadd; then
+    groupadd --system "$PLAYIT_GROUP"
+  elif have_command addgroup; then
+    addgroup -S "$PLAYIT_GROUP"
+  else
+    echo "Cannot create ${PLAYIT_GROUP} group: groupadd/addgroup not found" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if user_exists; then
+    return 0
+  fi
+
+  shell="$(nologin_shell)"
+  if have_command useradd; then
+    useradd --system --gid "$PLAYIT_GROUP" --home-dir "$PLAYIT_HOME" --no-create-home --shell "$shell" "$PLAYIT_USER"
+  elif have_command adduser; then
+    adduser -S -D -H -h "$PLAYIT_HOME" -s "$shell" -G "$PLAYIT_GROUP" "$PLAYIT_USER"
+  else
+    echo "Cannot create ${PLAYIT_USER} user: useradd/adduser not found" >&2
+    exit 1
+  fi
+}
+
+ensure_group
+ensure_user

--- a/build-scripts/nfpm/preinstall.sh
+++ b/build-scripts/nfpm/preinstall.sh
@@ -4,6 +4,8 @@ set -eu
 PLAYIT_USER=playit
 PLAYIT_GROUP=playit
 PLAYIT_HOME=/nonexistent
+SYSUSERS_CONFIG=/usr/lib/sysusers.d/playit.conf
+SYSUSERS_SHELL=/usr/sbin/nologin
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
@@ -66,5 +68,11 @@ ensure_user() {
   fi
 }
 
-ensure_group
-ensure_user
+if have_command systemd-sysusers && [ -f "$SYSUSERS_CONFIG" ]; then
+  systemd-sysusers "$SYSUSERS_CONFIG"
+elif have_command systemd-sysusers; then
+  systemd-sysusers --inline "u ${PLAYIT_USER} - \"playit service user\" ${PLAYIT_HOME} ${SYSUSERS_SHELL}"
+else
+  ensure_group
+  ensure_user
+fi


### PR DESCRIPTION
## Summary
- Remove the hard dependency on `systemd` from Arch and nfpm package metadata.
- Replace `systemd-sysusers` provisioning with shell-based user/group creation that falls back to `groupadd`/`addgroup` and `useradd`/`adduser`.
- Add OpenRC and systemd init payloads under `/opt/playit/share/init` so non-systemd installs can select the appropriate manager.
- Expand package build tests to verify the new init files and the removal of the `systemd` dependency.

## Testing
- `bash -n arch/bin/PKGBUILD`
- `bash -n arch/bin/playit-bin.install`
- `bash -n arch/build/PKGBUILD`
- `bash -n arch/build/playit.install`
- `sh -n build-scripts/nfpm/preinstall.sh`
- `sh -n build-scripts/nfpm/postinstall.sh`
- `arch/test-pkgbuilds.sh` checks updated package layout and dependency assertions
- Not run: full package builds on target distros