### PR TITLE
Improve TCP pipe direction logging

### DIFF
--- a/packages/agent_core/src/agent_control/address_selector.rs
+++ b/packages/agent_core/src/agent_control/address_selector.rs
@@ -25,12 +25,12 @@ impl<IO: PacketIO> AddressSelector<IO> {
         let mut buffer: Vec<u8> = Vec::new();
 
         for addr in self.options {
-            tracing::debug!(?addr, "trying to establish tunnel connection");
+            tracing::debug!(%addr, "probing tunnel control address");
 
             let is_ip6 = addr.is_ipv6();
             let attempts = if is_ip6 { 1 } else { 3 };
 
-            for _ in 0..attempts {
+            for attempt in 1..=attempts {
                 buffer.clear();
 
                 ControlRpcMessage {
@@ -44,7 +44,7 @@ impl<IO: PacketIO> AddressSelector<IO> {
                 .write_to(&mut buffer)?;
 
                 if let Err(error) = self.packet_io.send_to(&buffer, addr).await {
-                    tracing::error!(?error, ?addr, "failed to send initial ping");
+                    tracing::warn!(?error, %addr, "could not send probe ping to tunnel address");
                     break;
                 }
 
@@ -61,7 +61,11 @@ impl<IO: PacketIO> AddressSelector<IO> {
                     match res {
                         Ok(Ok((bytes, peer))) => {
                             if peer != addr {
-                                tracing::error!(?peer, ?addr, "got message from different source");
+                                tracing::debug!(
+                                    %peer,
+                                    %addr,
+                                    "ignoring probe response from unexpected source"
+                                );
                                 continue;
                             }
 
@@ -69,9 +73,9 @@ impl<IO: PacketIO> AddressSelector<IO> {
                             match ControlFeed::read_from(&mut reader) {
                                 Ok(ControlFeed::Response(msg)) => {
                                     if msg.request_id != 1 {
-                                        tracing::error!(
+                                        tracing::debug!(
                                             ?msg,
-                                            "got response with unexpected request_id"
+                                            "ignoring tunnel response for a different request_id"
                                         );
                                         continue;
                                     }
@@ -79,8 +83,9 @@ impl<IO: PacketIO> AddressSelector<IO> {
                                     match msg.content {
                                         ControlResponse::Pong(pong) => {
                                             tracing::debug!(
+                                                %addr,
                                                 ?pong,
-                                                "got initial pong from tunnel server"
+                                                "received initial pong from tunnel server"
                                             );
                                             return Ok(ConnectedControl::new(
                                                 addr,
@@ -89,34 +94,56 @@ impl<IO: PacketIO> AddressSelector<IO> {
                                             ));
                                         }
                                         other => {
-                                            tracing::error!(
+                                            tracing::debug!(
+                                                %addr,
                                                 ?other,
-                                                "expected pong got other response"
+                                                "expected pong, got a different control response"
                                             );
                                         }
                                     }
                                 }
                                 Ok(other) => {
-                                    tracing::error!(?other, "unexpected control feed");
+                                    tracing::debug!(
+                                        %addr,
+                                        ?other,
+                                        "expected control response, got something else"
+                                    );
                                 }
                                 Err(error) => {
-                                    tracing::error!(?error, test = ?(), "failed to parse response data");
+                                    tracing::debug!(
+                                        ?error,
+                                        %addr,
+                                        "could not parse tunnel control response"
+                                    );
                                 }
                             }
                         }
                         Ok(Err(error)) => {
-                            tracing::error!(?error, "failed to receive UDP packet");
+                            tracing::debug!(
+                                ?error,
+                                %addr,
+                                "udp recv failed while waiting for probe pong"
+                            );
                         }
                         Err(_) => {
-                            tracing::debug!(%addr, "waited {}ms for pong", (i + 1) * 500);
+                            tracing::trace!(
+                                %addr,
+                                waited_ms = (i + 1) * 500,
+                                "still waiting for pong from tunnel server"
+                            );
                         }
                     }
                 }
 
-                tracing::error!("timeout waiting for pong");
+                tracing::debug!(
+                    %addr,
+                    attempt,
+                    attempts,
+                    "no pong from tunnel server within timeout"
+                );
             }
 
-            tracing::error!("failed to ping tunnel server");
+            tracing::warn!(%addr, "failed to reach tunnel server after all attempts");
         }
 
         Err(SetupError::FailedToConnect)

--- a/packages/agent_core/src/agent_control/connected_control.rs
+++ b/packages/agent_core/src/agent_control/connected_control.rs
@@ -110,11 +110,18 @@ impl<IO: PacketIO> ConnectedControl<IO> {
                     match tokio::time::timeout(Duration::from_millis(500), self.recv()).await {
                         Ok(Ok(msg)) => msg,
                         Ok(Err(error)) => {
-                            tracing::error!(?error, "got error reading from socket");
+                            tracing::debug!(
+                                ?error,
+                                control_addr = %self.control_addr,
+                                "control socket recv failed during register; retrying"
+                            );
                             break;
                         }
                         Err(_) => {
-                            tracing::error!("timeout waiting for register response");
+                            tracing::debug!(
+                                control_addr = %self.control_addr,
+                                "no register response from tunnel within 500ms; retrying"
+                            );
                             continue;
                         }
                     };
@@ -124,7 +131,10 @@ impl<IO: PacketIO> ConnectedControl<IO> {
                         response
                     }
                     other => {
-                        tracing::error!(?other, "got unexpected response from register request");
+                        tracing::debug!(
+                            ?other,
+                            "ignoring control feed message that does not match register request_id"
+                        );
                         continue;
                     }
                 };
@@ -157,12 +167,15 @@ impl<IO: PacketIO> ConnectedControl<IO> {
                         }
                     }
                     ControlResponse::RequestQueued => {
-                        tracing::debug!("register queued, waiting 1s");
+                        tracing::debug!("tunnel server queued register request; waiting 1s");
                         tokio::time::sleep(Duration::from_secs(1)).await;
                         break;
                     }
                     other => {
-                        tracing::error!(?other, "expected AgentRegistered but got something else");
+                        tracing::debug!(
+                            ?other,
+                            "expected AgentRegistered response but got a different control response"
+                        );
                         continue;
                     }
                 };

--- a/packages/agent_core/src/agent_control/established_control.rs
+++ b/packages/agent_core/src/agent_control/established_control.rs
@@ -176,7 +176,7 @@ impl<A: AuthResource, IO: PacketIO> EstablishedControl<A, IO> {
 
         tracing::debug!(
             last_pong = ?self.pong_at_auth,
-            "authenticate control"
+            "control session authenticated with tunnel server"
         );
 
         Ok(())
@@ -192,7 +192,7 @@ impl<A: AuthResource, IO: PacketIO> EstablishedControl<A, IO> {
         if let ControlFeed::Response(res) = &feed {
             match &res.content {
                 ControlResponse::AgentRegistered(registered) => {
-                    tracing::debug!(details = ?registered, "agent registered");
+                    tracing::debug!(details = ?registered, "tunnel server confirmed agent registration");
                     self.registered = registered.clone();
                 }
                 ControlResponse::Pong(pong) => {
@@ -205,8 +205,8 @@ impl<A: AuthResource, IO: PacketIO> EstablishedControl<A, IO> {
 
                     if 10_000 < self.clock_offset.abs() {
                         tracing::warn!(
-                            offset = self.clock_offset,
-                            "local timestamp if over 10 seconds off"
+                            clock_offset_ms = self.clock_offset,
+                            "local clock differs from tunnel server by more than 10s; check system time"
                         );
                     }
 

--- a/packages/agent_core/src/agent_control/maintained_control.rs
+++ b/packages/agent_core/src/agent_control/maintained_control.rs
@@ -97,7 +97,11 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
             .try_timeout(Duration::from_secs(10))
             .await?;
 
-        tracing::info!(old = %self.control.conn.pong_latest.tunnel_addr, new = %connected.pong_latest.tunnel_addr, "update control address");
+        tracing::info!(
+            old_tunnel_addr = %self.control.conn.pong_latest.tunnel_addr,
+            new_tunnel_addr = %connected.pong_latest.tunnel_addr,
+            "switching control channel to new tunnel address"
+        );
         connected.reset_established(&mut self.control, registered);
 
         Ok(true)
@@ -115,7 +119,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
             .try_timeout(Duration::from_secs(5))
             .await
         {
-            tracing::error!(?error, "failed to send setup udp channel request");
+            tracing::warn!(?error, "failed to request udp channel setup from tunnel; will retry");
         }
 
         true
@@ -123,7 +127,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
 
     pub async fn update(&mut self) -> Option<TunnelControlEvent> {
         if let Some(reason) = self.control.is_expired() {
-            tracing::warn!(?reason, "control session expired; reconnecting");
+            tracing::warn!(?reason, "control session expired; reauthenticating");
 
             if let Err(error) = self
                 .control
@@ -131,7 +135,7 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
                 .try_timeout(Duration::from_secs(5))
                 .await
             {
-                tracing::error!(?error, "failed to authenticate");
+                tracing::error!(?error, "failed to reauthenticate control session");
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 return None;
             }
@@ -147,12 +151,12 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
                 .try_timeout(Duration::from_secs(1))
                 .await
             {
-                tracing::error!(?error, "failed to send ping");
+                tracing::warn!(?error, "failed to send control ping to tunnel; will retry");
             }
         }
 
         let time_till_expire = self.control.get_expire_at().max(now) - now;
-        tracing::trace!(time_till_expire, "time till expire");
+        tracing::trace!(time_till_expire_ms = time_till_expire, "control session ttl");
 
         /* keep alive every 60s or every 10s if expiring soon */
         let interval = if time_till_expire < 30_000 {
@@ -164,14 +168,17 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
         if interval < now - self.last_keep_alive {
             self.last_keep_alive = now;
 
-            tracing::debug!(time_till_expire, "send KeepAlive");
+            tracing::debug!(
+                time_till_expire_ms = time_till_expire,
+                "sending control keep-alive"
+            );
             if let Err(error) = self
                 .control
                 .send_keep_alive(100)
                 .try_timeout(Duration::from_secs(1))
                 .await
             {
-                tracing::error!(?error, "failed to send KeepAlive");
+                tracing::warn!(?error, "failed to send control keep-alive; will retry");
             }
         }
 
@@ -192,32 +199,34 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
                         return Some(TunnelControlEvent::UdpChannelDetails(details));
                     }
                     ControlResponse::Unauthorized => {
-                        tracing::debug!("session no longer authorized");
+                        tracing::info!(
+                            "tunnel server reports session as unauthorized; will reauthenticate"
+                        );
                         self.control.set_expired();
                     }
                     ControlResponse::Pong(pong) => {
                         self.last_pong = now_milli();
 
                         if pong.client_addr != self.control.pong_at_auth.client_addr {
-                            tracing::debug!(
-                                new_client = %pong.client_addr,
-                                old_client = %self.control.pong_at_auth.client_addr,
-                                "client ip changed"
+                            tracing::info!(
+                                new_client_addr = %pong.client_addr,
+                                old_client_addr = %self.control.pong_at_auth.client_addr,
+                                "tunnel server reports our client ip changed; session may expire"
                             );
                         }
                     }
                     msg => {
-                        tracing::debug!(?msg, "got response");
+                        tracing::debug!(?msg, "ignoring unhandled control response");
                     }
                 },
                 Ok(Err(error)) => {
-                    tracing::error!(?error, "failed to parse response");
+                    tracing::warn!(?error, "failed to parse message from tunnel control feed");
                 }
                 Err(_) => {
                     timeouts += 1;
 
                     if timeouts >= 10 {
-                        tracing::trace!("feed recv timeout");
+                        tracing::trace!("no control feed messages for 1s, yielding");
                         break;
                     }
                 }
@@ -225,7 +234,9 @@ impl<I: PacketIO, A: AuthResource> MaintainedControl<I, A> {
         }
 
         if self.last_pong != 0 && now_milli() - self.last_pong > 6_000 {
-            tracing::warn!("timeout waiting for pong");
+            tracing::warn!(
+                "no pong from tunnel server in 6s; marking session expired"
+            );
 
             self.last_pong = 0;
             self.control.set_expired();

--- a/packages/agent_core/src/network/lan_address.rs
+++ b/packages/agent_core/src/network/lan_address.rs
@@ -19,20 +19,22 @@ impl LanAddress {
             let socket = TcpSocket::new_v4()?;
 
             match socket.bind(SocketAddrV4::new(local_ip, 0).into()) {
-                Err(e) => {
+                Err(error) => {
                     tracing::debug!(
-                        "could not bind special loopback address; continuing without per-client loopback IP support: {:?}",
-                        e
+                        ?error,
+                        %local_ip,
+                        "could not bind per-client loopback ip; falling back to default local address"
                     );
                 }
                 Ok(_) => {
                     match socket.connect(host).await {
-                        Err(e) => {
+                        Err(error) => {
                             tracing::debug!(
-                                "could not connect using special loopback address {}; continuing with normal local address for flow {:?}: {:?}",
-                                local_ip,
-                                (peer, host),
-                                e
+                                ?error,
+                                %local_ip,
+                                %peer,
+                                %host,
+                                "could not connect via per-client loopback ip; falling back to default local address"
                             );
                         }
                         v => return v,
@@ -41,15 +43,21 @@ impl LanAddress {
             }
         }
 
-        tracing::debug!(is_loopback, host_ip = %host.ip(), special_lan_ip, "not using special lan address");
+        tracing::trace!(
+            is_loopback,
+            host_ip = %host.ip(),
+            special_lan_ip,
+            "connecting to origin without special loopback address"
+        );
         match TcpStream::connect(host).await {
-            Err(e) => {
-                tracing::error!(
-                    "Failed to establish connection for flow {:?} {:?}. Is your server running?",
-                    (peer, host),
-                    e
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    %peer,
+                    %host,
+                    "failed to connect to local origin server; is the server running and listening on the configured address?"
                 );
-                Err(e)
+                Err(error)
             }
             v => v,
         }
@@ -80,17 +88,19 @@ impl LanAddress {
                     match UdpSocket::bind(SocketAddrV4::new(local_ip, 0)).await {
                         Ok(v) => {
                             tracing::debug!(
-                                "could not bind preferred UDP source port {}; continuing with a random local port: {:?}",
+                                error = ?bad_port_error,
+                                %local_ip,
                                 local_port,
-                                bad_port_error
+                                "could not bind preferred UDP source port on per-client loopback ip; using a random local port"
                             );
                             Ok(v)
                         }
                         Err(bad_local_ip_err) => {
                             let v = UdpSocket::bind(SocketAddrV4::new(0.into(), 0)).await?;
                             tracing::debug!(
-                                "could not bind special loopback address for UDP; continuing without per-client loopback IP support: {:?}",
-                                bad_local_ip_err
+                                error = ?bad_local_ip_err,
+                                %local_ip,
+                                "could not bind per-client loopback ip for UDP; falling back to default local address"
                             );
                             Ok(v)
                         }
@@ -118,8 +128,9 @@ impl LanAddress {
                 Err(bad_port_error) => {
                     let v = UdpSocket::bind(fallback_addr).await?;
                     tracing::debug!(
-                        "could not bind preferred UDP source port; continuing with a random local port: {:?}",
-                        bad_port_error
+                        error = ?bad_port_error,
+                        local_port,
+                        "could not bind preferred UDP source port; using a random local port"
                     );
                     Ok(v)
                 }

--- a/packages/agent_core/src/network/tcp/tcp_clients.rs
+++ b/packages/agent_core/src/network/tcp/tcp_clients.rs
@@ -11,6 +11,7 @@ use tokio::{
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use crate::{
     network::{
@@ -171,7 +172,7 @@ impl Worker {
             let event = tokio::select! {
                 recv_opt = self.events.recv() => {
                     let Some(event) = recv_opt else {
-                        tracing::debug!("TcpClients worker closed because event channel closed");
+                        tracing::debug!("tcp clients worker stopping: event channel closed");
                         break;
                     };
                     event
@@ -181,7 +182,7 @@ impl Worker {
                     Event::ClearOld
                 },
                 _ = self.cancel.cancelled() => {
-                    tracing::debug!("TcpClients worker closed via cancel");
+                    tracing::debug!("tcp clients worker stopping: cancelled");
                     break
                 },
             };
@@ -191,12 +192,22 @@ impl Worker {
                     let client_id = self.next_client_id;
                     self.next_client_id = client_id + 1;
 
-                    tracing::info!(?details, id = client_id, "New TCP Client");
+                    let claim_addr = details.claim_instructions.address;
+                    tracing::info!(
+                        client_id,
+                        source_addr = %details.peer_addr,
+                        tunnel_addr = %details.connect_addr,
+                        tunnel_id = details.tunnel_id,
+                        port_offset = details.port_offset,
+                        %claim_addr,
+                        "new tcp client requested by tunnel"
+                    );
 
                     let Some(found) = self.lookup.lookup(details.tunnel_id, true).await else {
                         tracing::debug!(
+                            client_id,
                             tunnel_id = details.tunnel_id,
-                            "Could not find tunnel for new client"
+                            "no local tunnel mapping for new client; tunnel may have been removed or disabled"
                         );
                         tcp_errors().new_client_origin_not_found.inc();
                         continue;
@@ -221,7 +232,10 @@ impl Worker {
                         }
                         _ => {
                             tracing::error!(
-                                "Tunnel server provide miss match protol versions for peer and connect addr"
+                                client_id,
+                                source_addr = %details.peer_addr,
+                                tunnel_addr = %details.connect_addr,
+                                "tunnel server sent mismatched IP versions for peer and connect addresses; this is a protocol bug"
                             );
                             tcp_errors().invalid_proto_match.inc();
                             continue;
@@ -233,13 +247,19 @@ impl Worker {
                     let event_tx = self.events_tx.clone();
                     let stats = self.stats.clone();
                     let cancel = self.cancel.child_token();
+                    let connection_span = tracing::info_span!(
+                        "tcp_connection",
+                        client_id,
+                        source_addr = %details.peer_addr,
+                        tunnel_addr = %details.connect_addr,
+                        tunnel_id = details.tunnel_id,
+                        port_offset = details.port_offset,
+                    );
                     tokio::spawn(async move {
                         let Some(origin_addr) = found.resolve_local(details.port_offset).await
                         else {
-                            tracing::error!(
-                                port_offset = details.port_offset,
-                                tunnel_id = details.tunnel_id,
-                                "port offset not valid for tunnel"
+                            tracing::warn!(
+                                "tunnel sent port offset outside the configured range; check tunnel port_count and the agent config"
                             );
                             tcp_errors().new_client_invalid_port_offset.inc();
                             return;
@@ -251,29 +271,36 @@ impl Worker {
                             _ = cancel.cancelled() => return,
                             res = tokio::time::timeout(
                                 Duration::from_secs(8),
-                                TcpStream::connect(details.claim_instructions.address),
+                                TcpStream::connect(claim_addr),
                             ) => res,
                         };
 
                         let mut tunn_stream = match conn_res {
                             Ok(Ok(stream)) => stream,
                             Err(_) => {
-                                tracing::error!("timeout connecting to claim address");
+                                tracing::warn!(
+                                    %claim_addr,
+                                    "timed out (8s) connecting to playit tunnel server to claim client"
+                                );
                                 tcp_errors().new_client_claim_connect_timeout.inc();
                                 return;
                             }
                             Ok(Err(error)) => {
-                                tracing::error!(?error, "io error connecting to claim address");
+                                tracing::warn!(
+                                    ?error,
+                                    %claim_addr,
+                                    "failed to connect to playit tunnel server to claim client"
+                                );
                                 tcp_errors().new_client_claim_connect_error.inc();
                                 return;
                             }
                         };
 
                         if let Err(error) = tunn_stream.set_nodelay(setting_tcp_no_delay) {
-                            tracing::error!(
+                            tracing::debug!(
                                 ?error,
-                                "failed to set tunn tcp no delay, value: {}",
-                                setting_tcp_no_delay
+                                tcp_no_delay = setting_tcp_no_delay,
+                                "could not set TCP_NODELAY on tunnel-side socket; continuing without it"
                             );
                             tcp_errors().new_client_set_tunnel_no_delay_error.inc();
                         }
@@ -290,14 +317,18 @@ impl Worker {
                         match send_res {
                             Ok(Ok(_)) => {}
                             Err(_) => {
-                                tracing::error!("timeout sending claim token");
+                                tracing::warn!(
+                                    %claim_addr,
+                                    "timed out (8s) sending claim token to playit tunnel server"
+                                );
                                 tcp_errors().new_client_send_claim_timeout.inc();
                                 return;
                             }
                             Ok(Err(error)) => {
-                                tracing::error!(
+                                tracing::warn!(
                                     ?error,
-                                    "io error sending claim instruction to claim address"
+                                    %claim_addr,
+                                    "failed to send claim token to playit tunnel server"
                                 );
                                 tcp_errors().new_client_send_claim_error.inc();
                                 return;
@@ -315,12 +346,19 @@ impl Worker {
                         match confirm_res {
                             Ok(Ok(_)) => {}
                             Err(_) => {
-                                tracing::error!("timeout reading claim token response");
+                                tracing::warn!(
+                                    %claim_addr,
+                                    "timed out (4s) waiting for claim acknowledgement from playit tunnel server"
+                                );
                                 tcp_errors().new_client_claim_expect_timeout.inc();
                                 return;
                             }
                             Ok(Err(error)) => {
-                                tracing::error!(?error, "io error reading claim response");
+                                tracing::warn!(
+                                    ?error,
+                                    %claim_addr,
+                                    "failed to read claim acknowledgement from playit tunnel server"
+                                );
                                 tcp_errors().new_client_claim_expect_error.inc();
                                 return;
                             }
@@ -339,24 +377,18 @@ impl Worker {
                         let mut origin_stream = match connect_res {
                             Ok(Ok(stream)) => stream,
                             Ok(Err(error)) => {
-                                tracing::error!(
+                                tracing::warn!(
                                     ?error,
                                     %origin_addr,
-                                    tunnel_id = details.tunnel_id,
-                                    port_offset = details.port_offset,
-                                    source_addr = %details.peer_addr,
-                                    "failed to connect to local TCP server; check that your server is running and listening on the configured local address"
+                                    "failed to connect to local origin server; check that your server is running and listening on the configured local address"
                                 );
                                 tcp_errors().new_client_origin_connect_error.inc();
                                 return;
                             }
                             Err(_) => {
-                                tracing::error!(
+                                tracing::warn!(
                                     %origin_addr,
-                                    tunnel_id = details.tunnel_id,
-                                    port_offset = details.port_offset,
-                                    source_addr = %details.peer_addr,
-                                    "timed out connecting to local TCP server; check firewall rules and that the server is listening on the configured local address"
+                                    "timed out (2s) connecting to local origin server; check firewall rules and that the server is listening on the configured local address"
                                 );
                                 tcp_errors().new_client_origin_connect_timeout.inc();
                                 return;
@@ -364,7 +396,11 @@ impl Worker {
                         };
 
                         if let Err(error) = origin_stream.set_nodelay(true) {
-                            tracing::error!(?error, "failed to set origin tcp no delay");
+                            tracing::debug!(
+                                ?error,
+                                %origin_addr,
+                                "could not set TCP_NODELAY on origin-side socket; continuing without it"
+                            );
                             tcp_errors().new_client_set_origin_no_delay_error.inc();
                         }
 
@@ -393,12 +429,19 @@ impl Worker {
                         match proxy_write_res {
                             Ok(Ok(_)) => {}
                             Err(_) => {
-                                tracing::error!("timeout sending proxy protocol header");
+                                tracing::warn!(
+                                    %origin_addr,
+                                    "timed out (2s) sending PROXY protocol header to origin"
+                                );
                                 tcp_errors().new_client_write_proxy_proto_timeout.inc();
                                 return;
                             }
                             Ok(Err(error)) => {
-                                tracing::error!(?error, "failed to write proxy protocol header");
+                                tracing::warn!(
+                                    ?error,
+                                    %origin_addr,
+                                    "failed to send PROXY protocol header to origin"
+                                );
                                 tcp_errors().new_client_write_proxy_proto_error.inc();
                                 return;
                             }
@@ -407,6 +450,7 @@ impl Worker {
                         let tcp_client =
                             TcpClient::create_with_stats(tunn_stream, origin_stream, Some(stats))
                                 .await;
+                        tracing::debug!(%origin_addr, "tcp tunnel and origin connected; piping traffic");
                         let event = Event::ConnectedClient(Client {
                             id: client_id,
                             added_at: now_milli(),
@@ -421,7 +465,7 @@ impl Worker {
                             _ = cancel.cancelled() => return,
                             res = event_tx.send(event) => res,
                         };
-                    });
+                    }.instrument(connection_span));
                 }
                 Event::GetDetails(resp) => {
                     let _ = resp.send(self.clients.iter().map(Client::details).collect());
@@ -439,24 +483,42 @@ impl Worker {
                         let since_orig = now.max(last_use.origin_to_tunn) - last_use.origin_to_tunn;
 
                         if 90_000 < since_tunn && 30_000 < since_orig {
-                            tracing::debug!(id = client.id, "clear old: 90s since tunnel data");
+                            tracing::debug!(
+                                client_id = client.id,
+                                source_addr = %client.source_addr,
+                                origin_addr = %client.origin_addr,
+                                since_tunn_ms = since_tunn,
+                                "closing idle tcp client: 90s without tunnel-to-origin data"
+                            );
                             return false;
                         }
 
                         if 90_000 < since_orig && 30_000 < since_tunn {
-                            tracing::debug!(id = client.id, "clear old: 90s since origin data");
+                            tracing::debug!(
+                                client_id = client.id,
+                                source_addr = %client.source_addr,
+                                origin_addr = %client.origin_addr,
+                                since_orig_ms = since_orig,
+                                "closing idle tcp client: 90s without origin-to-tunnel data"
+                            );
                             return false;
                         }
 
                         if 60_000 < since_tunn && 60_000 < since_orig {
-                            tracing::debug!(id = client.id, "clear old: 60s since any data");
+                            tracing::debug!(
+                                client_id = client.id,
+                                source_addr = %client.source_addr,
+                                origin_addr = %client.origin_addr,
+                                since_tunn_ms = since_tunn,
+                                since_orig_ms = since_orig,
+                                "closing idle tcp client: 60s without traffic in either direction"
+                            );
                             return false;
                         }
 
                         true
                     });
 
-                    // Update active TCP connection count
                     self.stats.set_tcp(self.clients.len() as u32);
                 }
             }

--- a/packages/agent_core/src/network/tcp/tcp_pipe.rs
+++ b/packages/agent_core/src/network/tcp/tcp_pipe.rs
@@ -12,12 +12,30 @@ use crate::utils::now_milli;
 const TCP_PIPE_BUFFER_SIZE: usize = 16 * 1024;
 
 /// Direction of data flow for stats tracking
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PipeDirection {
     /// Data flowing from tunnel to local origin (bytes in)
     TunnelToOrigin,
     /// Data flowing from local origin to tunnel (bytes out)
     OriginToTunnel,
+}
+
+impl PipeDirection {
+    /// Name of the peer this pipe reads from.
+    fn read_source(self) -> &'static str {
+        match self {
+            Self::TunnelToOrigin => "tunnel",
+            Self::OriginToTunnel => "origin",
+        }
+    }
+
+    /// Name of the peer this pipe writes to.
+    fn write_destination(self) -> &'static str {
+        match self {
+            Self::TunnelToOrigin => "origin",
+            Self::OriginToTunnel => "tunnel",
+        }
+    }
 }
 
 pub struct TcpPipe {
@@ -117,13 +135,16 @@ struct Worker<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> {
 
 impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> Worker<R, W> {
     pub async fn start(mut self) {
+        let direction = self.direction;
+        let read_source = direction.read_source();
+        let write_destination = direction.write_destination();
         let mut buffer = vec![0u8; TCP_PIPE_BUFFER_SIZE];
 
         loop {
             // Keep the pipe cooperative when both sockets stay continuously ready.
             tokio::select! {
                 _ = self.cancel.cancelled() => {
-                    tracing::debug!("TcpPipe cancelled");
+                    tracing::debug!(?direction, "pipe cancelled before next read");
                     break;
                 }
                 _ = tokio::task::yield_now() => {}
@@ -134,27 +155,48 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> Worker<R, W> {
                 .run_until_cancelled(self.from.read(&mut buffer[..]))
                 .await
             else {
-                tracing::debug!("TcpPipe cancelled");
+                tracing::debug!(
+                    ?direction,
+                    "pipe cancelled while awaiting data from {read_source}"
+                );
                 break;
             };
 
             let byte_count = match read_res {
                 Ok(count) => count,
                 Err(error) => {
-                    tracing::error!(?error, "failed to read data");
+                    tracing::debug!(
+                        ?direction,
+                        ?error,
+                        "read from {read_source} failed; closing pipe"
+                    );
                     break;
                 }
             };
 
             if byte_count == 0 {
-                tracing::debug!("pipe ended due to EOF");
+                tracing::debug!(
+                    ?direction,
+                    "{read_source} closed the connection (EOF); closing pipe"
+                );
                 break;
             }
 
             if let Err(error) = self.to.write_all(&buffer[..byte_count]).await {
-                tracing::error!(?error, "failed to write data");
+                tracing::debug!(
+                    ?direction,
+                    bytes = byte_count,
+                    ?error,
+                    "write to {write_destination} failed; closing pipe"
+                );
                 break;
             }
+
+            tracing::trace!(
+                ?direction,
+                bytes = byte_count,
+                "forwarded chunk from {read_source} to {write_destination}"
+            );
 
             self.shared
                 .last_activity

--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -276,12 +276,12 @@ impl UdpClients {
         let socket = match key.create_socket(special_lan, target_addr).await {
             Ok(socket) => Arc::new(socket),
             Err(error) => {
-                tracing::error!(
+                tracing::warn!(
                     ?error,
-                    target_addr = %target_addr,
+                    %target_addr,
                     source_addr = %key.source_addr,
                     tunnel_id = key.tunnel_id,
-                    "failed to open local UDP socket for tunnel traffic"
+                    "failed to open local UDP socket for tunneled client; dropping packet"
                 );
                 return;
             }

--- a/packages/agent_core/src/network/udp/udp_receiver.rs
+++ b/packages/agent_core/src/network/udp/udp_receiver.rs
@@ -125,7 +125,11 @@ impl<I: PacketRx> Task<I> {
                 Err(error) => {
                     let now = tokio::time::Instant::now();
                     if next_error_log_allowed <= now {
-                        tracing::warn!(?error, id = self.id, "failed to receive UDP packet");
+                        tracing::warn!(
+                            ?error,
+                            receiver_id = self.id,
+                            "udp socket recv failed (logging at most once per second)"
+                        );
                         next_error_log_allowed = now + Duration::from_secs(1);
                     }
 

--- a/packages/agent_core/src/playit_agent.rs
+++ b/packages/agent_core/src/playit_agent.rs
@@ -123,7 +123,7 @@ impl PlayitAgent {
                         break;
                     };
                     if sent {
-                        tracing::debug!("udp channel requires auth, sent auth request");
+                        tracing::debug!("udp tunnel channel needs auth; sent setup request");
                     }
                 }
 
@@ -134,7 +134,10 @@ impl PlayitAgent {
                     let reload =
                         control.reload_control_addr(async { DualStackUdpSocket::new().await });
                     if let Some(Err(error)) = tunnel_cancel.run_until_cancelled(reload).await {
-                        tracing::error!(?error, "failed to reload_control_addr");
+                        tracing::warn!(
+                            ?error,
+                            "failed to refresh control addresses from api; keeping previous addresses"
+                        );
                     }
                 }
 
@@ -151,13 +154,13 @@ impl PlayitAgent {
                         }
                     }
                     Some(TunnelControlEvent::UdpChannelDetails(udp_details)) => {
-                        tracing::debug!("udp session details received");
+                        tracing::debug!("received udp channel session details from tunnel");
                         let _ = udp_session_tx.try_send(udp_details);
                     }
                     None => {}
                 }
             }
-        });
+        }.instrument(tracing::info_span!("tunnel_control")));
 
         let udp_cancel = cancel_token.child_token();
         let mut udp_channel = udp_channel;
@@ -184,7 +187,7 @@ impl PlayitAgent {
                     }
                     session_opt = udp_session_rx.recv() => {
                         let Some(session) = session_opt else {
-                            tracing::debug!("udp session channel closed");
+                            tracing::debug!("udp session channel closed; ending udp task");
                             break;
                         };
                         udp_channel.update_session(session).await;
@@ -212,13 +215,13 @@ impl PlayitAgent {
             result = &mut tunnel_task => {
                 tunnel_done = true;
                 if let Err(error) = result {
-                    tracing::error!(?error, "tunnel task failed");
+                    tracing::error!(?error, "tunnel control task panicked; agent will shut down");
                 }
             }
             result = &mut udp_task => {
                 udp_done = true;
                 if let Err(error) = result {
-                    tracing::error!(?error, "udp task failed");
+                    tracing::error!(?error, "udp dispatch task panicked; agent will shut down");
                 }
             }
             _ = cancel_token.cancelled() => {}

--- a/packages/api_client/src/http_client.rs
+++ b/packages/api_client/src/http_client.rs
@@ -77,7 +77,11 @@ impl PlayitHttpClient for HttpClient {
 
             let response_txt = response.text().await?;
             let result: ApiResult<Res, Err> = serde_json::from_str(&response_txt).map_err(|e| {
-                tracing::error!("failed to parse json:\n{}", response_txt);
+                tracing::error!(
+                    status = %response_status,
+                    body = %response_txt,
+                    "failed to parse playit api response as json"
+                );
                 HttpClientError::ParseError(e, response_status, response_txt.to_string())
             })?;
 
@@ -86,7 +90,11 @@ impl PlayitHttpClient for HttpClient {
         .await;
 
         if let Err(error) = &res {
-            tracing::error!(?error, request = %std::any::type_name::<Req>(), "API call failed");
+            tracing::warn!(
+                ?error,
+                request = %std::any::type_name::<Req>(),
+                "playit api call failed"
+            );
         }
 
         res

--- a/packages/playit-cli/src/main.rs
+++ b/packages/playit-cli/src/main.rs
@@ -353,7 +353,10 @@ pub async fn claim_exchange(
             let setup = match setup_res {
                 Ok(v) => v,
                 Err(error) => {
-                    tracing::error!(?error, "Failed loading claim setup");
+                    tracing::warn!(
+                        ?error,
+                        "claim setup poll failed; will retry in 2s"
+                    );
                     console
                         .write_screen(format!("{}\n\nError: {:?}", last_message, error))
                         .await;

--- a/packages/playitd/src/ipc_server.rs
+++ b/packages/playitd/src/ipc_server.rs
@@ -162,24 +162,24 @@ impl IpcServer {
                         Ok(stream) => {
                             let server = self.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = server.handle_client(stream).await {
-                                    if e.is_connection_closed() {
-                                        tracing::debug!("Client disconnected: {e}");
+                                if let Err(error) = server.handle_client(stream).await {
+                                    if error.is_connection_closed() {
+                                        tracing::debug!(?error, "ipc client disconnected");
                                     } else {
-                                        tracing::warn!("Client connection error: {e}");
+                                        tracing::warn!(?error, "ipc client connection error");
                                     }
                                 }
                             });
                         }
-                        Err(e) => {
-                            tracing::error!("Accept error: {e}");
+                        Err(error) => {
+                            tracing::error!(?error, "ipc listener accept failed");
                             // Avoid tight-loop logging if the listener enters a persistent failure state.
                             tokio::time::sleep(Duration::from_millis(100)).await;
                         }
                     }
                 }
                 _ = self.cancel_token.cancelled() => {
-                    tracing::info!("IPC server shutting down");
+                    tracing::info!("ipc server shutting down: cancellation requested");
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- Add `Debug` to `PipeDirection` and introduce helpers for naming the read source and write destination.
- Replace generic TCP pipe log messages with direction-aware messages that clearly state which peer was read from or written to.
- Downgrade expected shutdown/read/write failure paths to debug logging and add trace logging for successful forwarded chunks.

## Testing
- Not run (PR content generation only).
- Reviewed the diff to verify log messages now include pipe direction context and endpoint names.
- Confirmed no behavior changes beyond logging and message clarity.