### PR TITLE
[agent] update tunnel id from incoming packets.

### DIFF
--- a/packages/agent_core/src/network/udp/udp_clients.rs
+++ b/packages/agent_core/src/network/udp/udp_clients.rs
@@ -241,6 +241,9 @@ impl UdpClients {
                 let client = self.virtual_clients.get_mut(slot).unwrap();
 
                 client.from_tunnel_ts = now_ms;
+                client
+                    .flow
+                    .update_client_server_id(extension.client_server_id);
                 if client
                     .socket
                     .send_to(packet.as_ref(), client.target_addr)

--- a/packages/agent_core/tests/udp_tunnel_integration.rs
+++ b/packages/agent_core/tests/udp_tunnel_integration.rs
@@ -120,6 +120,47 @@ async fn encapsulated_udp_tunnel_relays_in_both_directions_and_recovers_same_flo
     assert_eq!(encap_flow_1, flow.flip());
     assert_eq!(encap_payload_1, tunnel_reply_1);
 
+    let flow_after_server_change = with_client_server_id(flow, 8);
+    let origin_payload_after_server_change = b"packet after tunnel server change";
+    send_tunneled_packet(
+        &tunnel_server,
+        channel_addr,
+        flow_after_server_change,
+        origin_payload_after_server_change,
+    )
+    .await;
+
+    let (changed_flow, changed_packet) = timeout(TEST_TIMEOUT, udp_channel.recv())
+        .await
+        .expect("recv packet after tunnel server change");
+    udp_clients
+        .handle_tunneled_packet(3_000, changed_flow, changed_packet)
+        .await;
+
+    let (changed_len, changed_virtual_addr, changed_bytes) = recv_from_socket(&origin_server).await;
+    assert_eq!(changed_virtual_addr, virtual_addr_1);
+    assert_eq!(
+        &changed_bytes[..changed_len],
+        origin_payload_after_server_change
+    );
+    assert_eq!(stats.active_udp(), 1);
+
+    let reply_after_server_change = b"reply after tunnel server change";
+    origin_server
+        .send_to(reply_after_server_change, changed_virtual_addr)
+        .await
+        .expect("origin send reply after tunnel server change");
+
+    let changed_reply = timeout(TEST_TIMEOUT, udp_clients.recv_origin_packet())
+        .await
+        .expect("recv origin reply after tunnel server change");
+    let (changed_reply_flow, changed_reply_packet) = udp_clients
+        .dispatch_origin_packet(4_000, changed_reply)
+        .await
+        .expect("dispatch origin reply after tunnel server change");
+    assert_eq!(changed_reply_flow, flow_after_server_change.flip());
+    assert_eq!(changed_reply_packet.as_ref(), reply_after_server_change);
+
     udp_clients.clear_old(100_000).await;
     assert_eq!(stats.active_udp(), 0);
 
@@ -488,6 +529,22 @@ fn flow_with_source(src_ip: Ipv4Addr, src_port: u16) -> UdpFlow {
             port_offset: 0,
         }),
     }
+}
+
+fn with_client_server_id(mut flow: UdpFlow, client_server_id: u64) -> UdpFlow {
+    let client_server_id = NonZeroU64::new(client_server_id).expect("nonzero client server id");
+    match &mut flow {
+        UdpFlow::V4 {
+            extension: Some(extension),
+            ..
+        }
+        | UdpFlow::V6 {
+            extension: Some(extension),
+            ..
+        } => extension.client_server_id = client_server_id,
+        _ => panic!("flow has no extension"),
+    }
+    flow
 }
 
 struct FlowCase {

--- a/packages/agent_proto/src/control_messages.rs
+++ b/packages/agent_proto/src/control_messages.rs
@@ -1283,5 +1283,4 @@ mod test {
         let err = ControlRequest::read_from(&mut &buffer[..]).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
-
 }

--- a/packages/agent_proto/src/udp_proto.rs
+++ b/packages/agent_proto/src/udp_proto.rs
@@ -57,10 +57,23 @@ impl UdpFlow {
         self.extension().map(|v| v.client_server_id)
     }
 
+    pub fn update_client_server_id(&mut self, client_server_id: NonZeroU64) {
+        if let Some(extension) = self.extension_mut() {
+            extension.client_server_id = client_server_id;
+        }
+    }
+
     pub fn extension(&self) -> Option<&UdpFlowExtension> {
         match self {
             Self::V4 { extension, .. } => extension.as_ref(),
             Self::V6 { extension, .. } => extension.as_ref(),
+        }
+    }
+
+    pub fn extension_mut(&mut self) -> Option<&mut UdpFlowExtension> {
+        match self {
+            Self::V4 { extension, .. } => extension.as_mut(),
+            Self::V6 { extension, .. } => extension.as_mut(),
         }
     }
 


### PR DESCRIPTION
Otherwise outgoing packets contained the stale tunnel id.