### PR TITLE
Add CLI configuration for TCP connection rate limits

### DIFF
--- a/packages/agent_core/src/network/tcp/tcp_settings.rs
+++ b/packages/agent_core/src/network/tcp/tcp_settings.rs
@@ -5,10 +5,12 @@ pub struct TcpSettings {
     pub tcp_no_delay: bool,
 }
 
+pub const DEFAULT_NEW_CLIENT_RATELIMIT: u32 = 5;
+
 impl Default for TcpSettings {
     fn default() -> Self {
         Self {
-            new_client_ratelimit: 5,
+            new_client_ratelimit: DEFAULT_NEW_CLIENT_RATELIMIT,
             new_client_ratelimit_burst: 32,
             tcp_no_delay: true,
         }

--- a/packages/playit-cli/src/client.rs
+++ b/packages/playit-cli/src/client.rs
@@ -626,6 +626,35 @@ pub async fn run_secret_path_command(target: &CliTarget) -> Result<(), CliError>
     Ok(())
 }
 
+pub async fn run_tcp_rate_limit_command(
+    target: &CliTarget,
+    value: Option<u32>,
+) -> Result<(), CliError> {
+    let mut client = connect_target(target).await?;
+    if let Some(value) = value {
+        let response = client.set_tcp_rate_limit(value).await.map_err(|error| {
+            CliError::IpcError(format!("Failed to set TCP rate limit: {error}"))
+        })?;
+        if !response.accepted {
+            return Err(CliError::IpcError(response.message.unwrap_or_else(|| {
+                "playitd rejected the TCP rate limit".to_string()
+            })));
+        }
+        println!(
+            "{}",
+            response
+                .message
+                .unwrap_or_else(|| "TCP rate limit saved".to_string())
+        );
+    } else {
+        let response = client.get_tcp_rate_limit().await.map_err(|error| {
+            CliError::IpcError(format!("Failed to get TCP rate limit: {error}"))
+        })?;
+        println!("{}", response.value);
+    }
+    Ok(())
+}
+
 pub async fn run_account_login_url_command(target: &CliTarget) -> Result<(), CliError> {
     let mut client = connect_target(target).await?;
     let response = client.get_account_login_url().await.map_err(|error| {

--- a/packages/playit-cli/src/main.rs
+++ b/packages/playit-cli/src/main.rs
@@ -8,6 +8,7 @@ use client::{
     AttachMode, CliTarget, ensure_service_waiting_for_secret, provision_service_secret,
     run_account_login_url_command, run_attach_command, run_auto_command, run_reset_command,
     run_secret_path_command, run_start_command, run_status_command, run_stop_command,
+    run_tcp_rate_limit_command,
 };
 use playit_agent_core::agent_control::platform::current_platform;
 use playit_agent_core::agent_control::version::{help_register_version, register_platform};
@@ -85,6 +86,12 @@ enum Commands {
     /// Shows the file path where the playit secret can be found
     SecretPath,
 
+    /// Get or set the new TCP connection rate limit
+    TcpRateLimit {
+        #[command(subcommand)]
+        command: TcpRateLimitCommands,
+    },
+
     /// Setup playit by provisioning a new secret to playitd
     Setup,
 
@@ -109,6 +116,14 @@ enum Commands {
 enum AccountCommands {
     /// Generates a link to allow user to login
     LoginUrl,
+}
+
+#[derive(Subcommand)]
+enum TcpRateLimitCommands {
+    /// Print the configured rate limit
+    Get,
+    /// Set the rate limit in connections per second
+    Set { value: u32 },
 }
 
 #[derive(Subcommand)]
@@ -215,6 +230,13 @@ async fn run_cli() -> Result<std::process::ExitCode, CliError> {
         }
         Some(Commands::SecretPath) => {
             run_secret_path_command(&target).await?;
+        }
+        Some(Commands::TcpRateLimit { command }) => {
+            let value = match command {
+                TcpRateLimitCommands::Get => None,
+                TcpRateLimitCommands::Set { value } => Some(value),
+            };
+            run_tcp_rate_limit_command(&target, value).await?;
         }
         Some(Commands::Account { ref command }) => match command {
             AccountCommands::LoginUrl => {

--- a/packages/playit-ipc/src/ipc.rs
+++ b/packages/playit-ipc/src/ipc.rs
@@ -16,7 +16,7 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use crate::endpoint::IpcEndpoint;
 use crate::model::{
     AccountLoginUrlResponse, AgentLifecycle, CommandResponse, ProtocolInfo, SecretPathResponse,
-    ServiceError, ServiceStatus, ServiceUpdate, SubscribeResponse,
+    ServiceError, ServiceStatus, ServiceUpdate, SubscribeResponse, TcpRateLimitResponse,
 };
 
 pub const IPC_VERSION: u32 = 2;
@@ -105,6 +105,8 @@ pub enum ServiceRequest {
     SetSecret { secret: String },
     ResetSecret,
     GetSecretPath,
+    GetTcpRateLimit,
+    SetTcpRateLimit { value: u32 },
     GetAccountLoginUrl,
 }
 
@@ -157,6 +159,8 @@ pub enum ServiceResponse {
     SetSecret(CommandResponse),
     ResetSecret(CommandResponse),
     SecretPath(SecretPathResponse),
+    TcpRateLimit(TcpRateLimitResponse),
+    SetTcpRateLimit(CommandResponse),
     AccountLoginUrl(AccountLoginUrlResponse),
     Error(ServiceError),
 }
@@ -201,6 +205,7 @@ pub fn protocol_info() -> ProtocolInfo {
             "lifecycle_state".to_string(),
             "rich_status".to_string(),
             "secret_provisioning".to_string(),
+            "tcp_rate_limit_configuration".to_string(),
         ],
     }
 }
@@ -507,6 +512,29 @@ impl IpcClient {
         )
     }
 
+    pub async fn get_tcp_rate_limit(&mut self) -> Result<TcpRateLimitResponse, IpcError> {
+        expect_response(
+            self.request(ServiceRequest::GetTcpRateLimit).await?,
+            "TCP rate limit response",
+            |response| match response {
+                ServiceResponse::TcpRateLimit(response) => Some(response),
+                _ => None,
+            },
+        )
+    }
+
+    pub async fn set_tcp_rate_limit(&mut self, value: u32) -> Result<CommandResponse, IpcError> {
+        expect_response(
+            self.request(ServiceRequest::SetTcpRateLimit { value })
+                .await?,
+            "set TCP rate limit response",
+            |response| match response {
+                ServiceResponse::SetTcpRateLimit(response) => Some(response),
+                _ => None,
+            },
+        )
+    }
+
     pub async fn get_account_login_url(&mut self) -> Result<AccountLoginUrlResponse, IpcError> {
         expect_response(
             self.request(ServiceRequest::GetAccountLoginUrl).await?,
@@ -646,6 +674,8 @@ pub fn is_known_request_type(type_name: &str) -> bool {
             | "set_secret"
             | "reset_secret"
             | "get_secret_path"
+            | "get_tcp_rate_limit"
+            | "set_tcp_rate_limit"
             | "get_account_login_url"
     )
 }

--- a/packages/playit-ipc/src/model.rs
+++ b/packages/playit-ipc/src/model.rs
@@ -172,6 +172,11 @@ pub struct SecretPathResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TcpRateLimitResponse {
+    pub value: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AccountLoginUrlResponse {
     pub login_url: String,
 }

--- a/packages/playitd/src/daemon.rs
+++ b/packages/playitd/src/daemon.rs
@@ -9,7 +9,7 @@ use playit_agent_core::agent_control::errors::SetupError;
 use playit_agent_core::agent_control::platform::current_platform;
 use playit_agent_core::agent_control::version::{help_register_version, register_platform};
 use playit_agent_core::network::origin_lookup::{OriginLookup, OriginResource, OriginTarget};
-use playit_agent_core::network::tcp::tcp_settings::TcpSettings;
+use playit_agent_core::network::tcp::tcp_settings::{DEFAULT_NEW_CLIENT_RATELIMIT, TcpSettings};
 use playit_agent_core::network::udp::udp_settings::UdpSettings;
 use playit_agent_core::playit_agent::{PlayitAgent, PlayitAgentSettings};
 use playit_agent_core::stats::AgentStats;
@@ -252,6 +252,16 @@ impl SecretSource {
         }
     }
 
+    async fn tcp_new_client_rate_limit(&self) -> u32 {
+        let Self::File { path } = self else {
+            return DEFAULT_NEW_CLIENT_RATELIMIT;
+        };
+        load_secret_config(path)
+            .await
+            .map(|config| config.tcp_new_client_rate_limit)
+            .unwrap_or(DEFAULT_NEW_CLIENT_RATELIMIT)
+    }
+
     fn secret_provision_error(&self) -> ServiceError {
         match self {
             Self::Inline { .. } => daemon_error(
@@ -301,9 +311,15 @@ pub async fn run_daemon(options: DaemonOptions) -> Result<(), DaemonError> {
         return Ok(());
     };
 
-    let Some(agent) =
-        build_agent_with_reprovisioning(&mut runtime, &secret_source, &mut secret_rx, secret_code)
-            .await?
+    let tcp_new_client_rate_limit = secret_source.tcp_new_client_rate_limit().await;
+    let Some(agent) = build_agent_with_reprovisioning(
+        &mut runtime,
+        &secret_source,
+        &mut secret_rx,
+        secret_code,
+        tcp_new_client_rate_limit,
+    )
+    .await?
     else {
         return Ok(());
     };
@@ -529,6 +545,7 @@ async fn build_agent_with_reprovisioning(
     secret_source: &SecretSource,
     secret_rx: &mut Option<mpsc::Receiver<SecretProvisionRequest>>,
     secret_code: String,
+    tcp_new_client_rate_limit: u32,
 ) -> Result<Option<AgentRuntime>, DaemonError> {
     let lookup = Arc::new(OriginLookup::default());
     let mut secret_code = secret_code;
@@ -543,7 +560,10 @@ async fn build_agent_with_reprovisioning(
 
         let settings = PlayitAgentSettings {
             udp_settings: UdpSettings::default(),
-            tcp_settings: TcpSettings::default(),
+            tcp_settings: TcpSettings {
+                new_client_ratelimit: tcp_new_client_rate_limit,
+                ..TcpSettings::default()
+            },
             api_url: api_base(),
             secret_key: secret_code.clone(),
         };
@@ -1002,6 +1022,7 @@ async fn persist_secret_file(path: &Path, secret: &str) -> Result<(), String> {
     let content = if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
         toml::to_string(&SecretConfig {
             secret_key: secret.clone(),
+            tcp_new_client_rate_limit: DEFAULT_NEW_CLIENT_RATELIMIT,
         })
         .map_err(|error| {
             format!(
@@ -1115,6 +1136,34 @@ fn parse_secret_file(content: &str) -> Result<String, ()> {
     validate_secret(config.secret_key.trim()).map_err(|_| ())
 }
 
+pub(crate) async fn load_secret_config(path: &Path) -> Result<SecretConfig, String> {
+    let content = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|error| format!("Failed to read secret file {}: {error}", path.display()))?;
+    let trimmed = content.trim();
+    if let Ok(secret_key) = validate_secret(trimmed) {
+        return Ok(SecretConfig {
+            secret_key,
+            tcp_new_client_rate_limit: DEFAULT_NEW_CLIENT_RATELIMIT,
+        });
+    }
+    toml::from_str(&content)
+        .map_err(|error| format!("Invalid secret file {}: {error}", path.display()))
+}
+
+pub(crate) async fn persist_secret_config(
+    path: &Path,
+    config: &SecretConfig,
+) -> Result<(), String> {
+    let content = toml::to_string(config).map_err(|error| {
+        format!(
+            "Failed to serialize secret file {}: {error}",
+            path.display()
+        )
+    })?;
+    secure_write_secret_file(path, content.as_bytes()).await
+}
+
 fn validate_secret(secret: &str) -> Result<String, String> {
     hex::decode(secret)
         .map(|_| secret.to_string())
@@ -1124,8 +1173,14 @@ fn validate_secret(secret: &str) -> Result<String, String> {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-struct SecretConfig {
-    secret_key: String,
+pub(crate) struct SecretConfig {
+    pub(crate) secret_key: String,
+    #[serde(default = "default_tcp_new_client_rate_limit")]
+    pub(crate) tcp_new_client_rate_limit: u32,
+}
+
+fn default_tcp_new_client_rate_limit() -> u32 {
+    DEFAULT_NEW_CLIENT_RATELIMIT
 }
 
 fn parse_version_part(part: &str) -> Result<u32, String> {

--- a/packages/playitd/src/ipc_server.rs
+++ b/packages/playitd/src/ipc_server.rs
@@ -19,7 +19,7 @@ use playit_ipc::ipc::{
 use playit_ipc::model::{
     AccountLoginUrlResponse, AgentLifecycle, CommandResponse, ConnectionStats, SecretPathResponse,
     ServiceError, ServiceErrorCode, ServiceStatus, ServiceUpdate, SubscribeResponse,
-    SubscriptionSnapshot,
+    SubscriptionSnapshot, TcpRateLimitResponse,
 };
 use serde_json::json;
 use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
@@ -327,6 +327,12 @@ impl IpcServer {
                         .map(|path| path.display().to_string()),
                 }))
             }
+            ServiceRequest::GetTcpRateLimit => {
+                RequestOutcome::respond(self.get_tcp_rate_limit_response().await)
+            }
+            ServiceRequest::SetTcpRateLimit { value } => {
+                RequestOutcome::respond(self.set_tcp_rate_limit_response(value).await)
+            }
             ServiceRequest::GetAccountLoginUrl => {
                 RequestOutcome::respond(self.account_login_url_response().await)
             }
@@ -405,6 +411,53 @@ impl IpcServer {
             }
             Err(error) => ServiceResponse::Error(error),
         }
+    }
+
+    async fn get_tcp_rate_limit_response(&self) -> ServiceResponse {
+        match self.load_secret_config().await {
+            Ok(config) => ServiceResponse::TcpRateLimit(TcpRateLimitResponse {
+                value: config.tcp_new_client_rate_limit,
+            }),
+            Err(error) => ServiceResponse::Error(error),
+        }
+    }
+
+    async fn set_tcp_rate_limit_response(&self, value: u32) -> ServiceResponse {
+        if value == 0 {
+            return ServiceResponse::Error(protocol_error(
+                ServiceErrorCode::InvalidRequest,
+                "TCP rate limit must be greater than zero".to_string(),
+                false,
+            ));
+        }
+        let Some(secret_path) = &self.secret_path else {
+            return ServiceResponse::Error(self.secret_provision_error.clone());
+        };
+        let mut config = match self.load_secret_config().await {
+            Ok(config) => config,
+            Err(error) => return ServiceResponse::Error(error),
+        };
+        config.tcp_new_client_rate_limit = value;
+        match crate::daemon::persist_secret_config(secret_path, &config).await {
+            Ok(()) => ServiceResponse::SetTcpRateLimit(CommandResponse {
+                accepted: true,
+                message: Some("TCP rate limit saved; restart playitd to apply it".to_string()),
+            }),
+            Err(message) => ServiceResponse::Error(protocol_error(
+                ServiceErrorCode::SecretWriteFailed,
+                message,
+                true,
+            )),
+        }
+    }
+
+    async fn load_secret_config(&self) -> Result<crate::daemon::SecretConfig, ServiceError> {
+        let Some(secret_path) = &self.secret_path else {
+            return Err(self.secret_provision_error.clone());
+        };
+        crate::daemon::load_secret_config(secret_path)
+            .await
+            .map_err(|message| protocol_error(ServiceErrorCode::InvalidRequest, message, false))
     }
 
     async fn send_response<W: tokio::io::AsyncWrite + Unpin>(


### PR DESCRIPTION
## Summary

- Add `tcp-rate-limit get` and `set` CLI commands.
- Persist the TCP connection rate limit in the secret configuration.
- Add IPC requests and responses for reading and updating the limit.
- Keep the default limit at 5 connections per second.
- Require a daemon restart after changing the setting.

## Testing

- Not run.